### PR TITLE
Port to Python 3 + add single-file browser app (SCELSE fork)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,106 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repo is
+
+SCELSE fork of the Alm Lab AdaptML tool (Hunt et al., *Science* 320:1081, 2008). Two parallel implementations of the same algorithm:
+
+1. **Python 3 CLI** — original pipeline, ported from Python 2.5 to modern Python 3 + NumPy/SciPy
+2. **`adaptml.html`** — complete JS reimplementation in a single self-contained browser file
+
+## Running the browser app
+
+```bash
+python3 -m http.server 8000
+# visit http://localhost:8000/adaptml.html
+```
+
+A local server is required only for the "Load example" button (`fetch` is blocked on `file://`). Without it, users can paste the tree manually.
+
+## Running the Python CLI
+
+```bash
+python3 -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt
+
+# End-to-end on the Vibrio example:
+python3 wrapper/WrAdaptMLFile.py example/adaptml.file      # Step 1: habitat learning
+python3 wrapper/WrapLikelihoodFile.py example/likelihood.file  # Step 2: cluster identification
+```
+
+Outputs go to `example/output/`. The two config files (`adaptml.file`, `likelihood.file`) are the canonical entry points; the underlying scripts can also be invoked directly with keyword= arguments.
+
+## Architecture
+
+### Python pipeline — two-stage design
+
+**Stage 1 — Habitat learning** (`habitats/trunk/AdaptML.py`)
+- Reads an unrooted Newick tree + optional params
+- EM loop: `LearnLiks` (Felsenstein pruning) → `EstimateStates` (marginal posterior per node) → `LearnRates` (update habitat emission matrix + µ)
+- Merges similar habitats (sum-of-squared-diffs < `collapse_thresh`)
+- Writes `habitat.matrix` and `mu.val`
+
+**Stage 2 — Cluster identification** (`clusters/trunk/JointML.py`)
+- Reads outputs from Stage 1
+- Joint Viterbi assigns one best habitat to every node
+- Leaf-label shuffling (`clusters/getstats/rand_JointML.py`) builds per-node empirical null distributions
+- `GetLikelihoods.py` converts randomization outputs to per-node likelihood thresholds
+- Significant clusters: subtree ≥ 90% habitat-coherent AND joint likelihood > empirical threshold (`thresh`)
+- Writes iTOL files: `full.file`, `cluster.file`, `prune.file`, `bars.file`, `itol.tree`, `strain.names`
+
+**Shared modules** (both stages have their own copy under `habitats/trunk/` and `clusters/trunk/`):
+- `ML.py` — Felsenstein pruning, `LearnLiks`, `EstimateStates`, `LearnRates`/`NodeRate`
+- `multitree.py` — tree container, `LeafShuffle` for randomization
+- `node.py` — node class, all recursive tree operations (`PieCharts`, `FulliTol`, `ClusterTest`, etc.)
+- `branch.py` — branch class
+
+`clusters/getstats/` mirrors the cluster stage but with `rand_` prefix (randomization variants that shuffle leaf labels and recompute likelihoods).
+
+### Wrapper scripts
+
+`wrapper/WrAdaptMLFile.py` / `WrapLikelihoodFile.py` — parse the `.file` configs and call the underlying scripts via `subprocess` using `sys.executable`.
+
+### Browser app (`adaptml.html`)
+
+Single file (~1900 lines), all CSS + JS inlined. Structure:
+- **Newick parser** — handles bootstrap labels, zero-length branches
+- **`rootify()`** — midpoint-splits the outgroup edge to create a rooted tree; assigns `parent`/`children`/`leaf_nodes` on every node
+- **Habitat EM** — JS port of `habitats/trunk/ML.py` + `AdaptML.py`; runs in an inline Web Worker (Blob URL) so the UI stays responsive; posts progress events
+- **Joint Viterbi** — JS port of `clusters/trunk/ML.py`
+- **`runRandomizations()`** — shuffles leaf ecology labels N times, records per-node likelihoods, computes percentile threshold
+- **`findClusters()`** — post-order divergence detection + `tryCluster` descent (≥90% coherence + likelihood > threshold); each node guarded with `if (!node.cluster_root)` to prevent double-counting
+- **Output writers** — `writeNewick` (embeds `N00001…` internal IDs), `writeTreeColorsDataset` (TREE_COLORS range — population clade bands), `writeSymbolsDataset` (DATASET_SYMBOL — habitat circles), `writeColorstripDataset` (DATASET_COLORSTRIP — per-position ecology rings), `writeMultibarDataset` (DATASET_MULTIBAR), plus JSON/TSV outputs and an inline ZIP writer (STORED/uncompressed, CRC32)
+
+### Key algorithm parameters (publication defaults)
+
+| Parameter | Default | Notes |
+|---|---|---|
+| `init_hab_num` | 16 | Initial habitat count for EM |
+| `collapse_thresh` | 0.10 | Merge habitats with sum-sq-diff < this |
+| `converge_thresh` | 0.001 | Stop EM when habitat matrix change < this |
+| `thresh` / `thresh_p` | 0.9999 | Empirical p-value (p < 0.0001); use 0.95 for quick exploration |
+| `rand_iters` | 10000 | Randomization iterations for empirical null |
+| `seed` | 2727 | RNG seed for reproducibility |
+| Coherence cutoff | 90% | Subtree must be ≥90% same-habitat to qualify as a population |
+
+### numpy 2.x gotcha
+
+`from numpy import *` shadows builtin `sum`. Any file that sums `dict.values()` must use `_builtin_sum`:
+```python
+from builtins import sum as _builtin_sum
+scale = _builtin_sum(habitat_matrix[habitat].values())
+```
+This is already applied in `habitats/trunk/AdaptML.py` and `clusters/trunk/JointML.py`.
+
+### iTOL output files
+
+| File | iTOL format | Visualises |
+|---|---|---|
+| `tree.nwk` | Newick (internal nodes named `N00001…`) | Tree topology |
+| `dataset_population_strips.txt` | `TREE_COLORS range` | Population clade wedges (alternating blue/gray) |
+| `dataset_habitat_symbols.txt` | `DATASET_SYMBOL` | Habitat circles at cluster roots |
+| `dataset_ecology_pos*.txt` | `DATASET_COLORSTRIP` | Per-position ecology rings (one file per position) |
+| `habitats.json` | JSON | Emission probability matrix |
+| `populations.tsv` | TSV | Cluster members |
+
+In iTOL, set **"Colored ranges" → Cover → Clade** (or Tree) to render `dataset_population_strips.txt` as filled wedge sectors rather than thin arcs.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,112 @@
 AdaptML
 =======
 
-[![Code Climate](https://codeclimate.com/github/almlab/adaptml/badges/gpa.svg)](https://codeclimate.com/github/almlab/adaptml)
-[![Dependency Status](https://gemnasium.com/almlab/adaptml.svg)](https://gemnasium.com/almlab/adaptml)
+Automatically partition a gene phylogeny by using genetic and ecological similarity.
 
-Automatically partition a gene phylogeny by using genetic and ecological similarity
+This is a SCELSE fork of Lawrence David's [almlab/adaptml](https://github.com/almlab/adaptml).
+It ships **two** ways to run the same analysis:
 
-See
- - http://almlab.mit.edu/adaptml/
- - http://www.ncbi.nlm.nih.gov/pubmed/18497299
+1. **Python 3 CLI** — the original Python pipeline, ported to modern Python.
+2. **`adaptml.html`** — a single self-contained browser app (no install required) that runs the entire AdaptML algorithm in JavaScript and emits files in the **current** iTOL upload format.
+
+Both reproduce Figure 1A–B of [Hunt, David, Gevers, Preheim, Alm & Polz, *Science* 320:1081 (2008)](http://www.ncbi.nlm.nih.gov/pubmed/18497299).
+
+---
+
+## 1. Python 3 CLI
+
+### Install
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Run the included Vibrionaceae example
+
+```bash
+python3 wrapper/WrAdaptMLFile.py    example/adaptml.file
+python3 wrapper/WrapLikelihoodFile.py example/likelihood.file
+```
+
+Outputs land under `example/output/`:
+
+| File | Meaning |
+|---|---|
+| `habitat.matrix` | Inferred emission probability matrix (habitat → environment) |
+| `mu.val` | Inferred transition rate µ |
+| `stats.file` | EM convergence log |
+| `emp_trees/` | Per-iteration randomization likelihoods used for empirical significance |
+| `thresh.file` | Per-node empirical likelihood threshold |
+| `itol.tree` | Rooted Newick tree for iTOL |
+| `full.file` | Full iTOL dataset (legacy format) |
+| `cluster.file` | Significant clusters / habitat circles |
+| `prune.file`, `prune.tree`, `bars.file` | Pruned-tree summary (Fig 1B equivalent) |
+| `habitat.file` | Per-leaf habitat assignment |
+| `lik.file` | Joint likelihood + AIC |
+| `strain.names` | Member strains of every significant cluster |
+
+### Run on your own data
+
+Make a copy of `example/adaptml.file` and `example/likelihood.file`, edit:
+
+- `tree=…` — Newick tree where leaf names follow `EcologyID_SequenceID` (see `readme.pdf` §2.1.1.1)
+- `outgroup=…` — name of the outgroup leaf
+- `init_hab_num=16`, `collapse_thresh=0.1`, `converge_thresh=0.001`, `rateopt=avg` — defaults match the published paper
+- `color=…` — single-space-delimited color spec; see `example/color.file`
+- `thresh=0.9999` — empirical p-value threshold (use 0.9999 for the published p < 0.0001; 0.95 for quicker exploration)
+
+Or call the two component scripts directly (see `readme.pdf` §2 for the full syntax).
+
+---
+
+## 2. `adaptml.html` (single-file browser app)
+
+`adaptml.html` is a self-contained HTML/JS/CSS file. Open it in any modern browser:
+
+```bash
+python3 -m http.server 8000
+# then visit http://localhost:8000/adaptml.html
+
+# To stop the server:
+pkill -f "http.server 8000"
+```
+
+(A local web server is needed only so the "Load example" button can `fetch` the bundled `example/vibrio.hsp60.tree`; without it you can still paste a tree by hand.)
+
+The app re-implements the AdaptML algorithm in JavaScript with publication-grade defaults (see below), runs in a Web Worker so the page stays responsive, and produces a ZIP of modern iTOL dataset files ready to drag-and-drop onto your tree at [itol.embl.de](https://itol.embl.de/).
+
+### Publication-grade defaults
+
+| Parameter | Default | Notes |
+|---|---|---|
+| Initial habitats | 16 | Matches SOM |
+| Collapse threshold | 0.10 | Merges similar habitats |
+| Convergence threshold | 0.001 | EM stop criterion |
+| Empirical significance percentile | **0.9999** | p < 0.0001; use 0.95 for quick exploration (~1 min) |
+| Randomization iterations | **10000** | ~10 min on the vibrio dataset |
+| Random seed | 2727 | For reproducibility |
+
+### Output files and iTOL upload
+
+Download the ZIP from the results panel and upload to [itol.embl.de](https://itol.embl.de/):
+
+| File | iTOL format | Visualises |
+|---|---|---|
+| `tree.nwk` | Newick (internal nodes named `N00001…`) | Tree topology — upload this first |
+| `dataset_population_strips.txt` | `TREE_COLORS range` | Ecological population clade wedges (alternating blue/gray, numbered) |
+| `dataset_habitat_symbols.txt` | `DATASET_SYMBOL` | Habitat circles at cluster root nodes |
+| `dataset_ecology_pos*.txt` | `DATASET_COLORSTRIP` | Per-position ecology rings (one file per ecology position) |
+| `habitats.json` | JSON | Learned emission probability matrix |
+| `populations.tsv` | TSV | Per-population: habitat, leaf count, member names |
+| `stats.tsv` | TSV | EM convergence log |
+
+**iTOL tip for population wedges:** after uploading `dataset_population_strips.txt`, click the **"Colored ranges"** dataset in the iTOL panel and set **Cover → Clade** (or **Tree**) so each population fills a solid wedge sector rather than a thin outer arc.
+
+---
+
+## References
+
+- Hunt DE, David LA, Gevers D, Preheim SP, Alm EJ, Polz MF. *Resource Partitioning and Sympatric Differentiation Among Closely Related Bacterioplankton*. Science 320(5879):1081–1085 (2008). doi:10.1126/science.1157890
+- Original tool guide: see `readme.pdf` in this repo.

--- a/adaptml.html
+++ b/adaptml.html
@@ -1,0 +1,1982 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>AdaptML · SCELSE</title>
+<style>
+  :root {
+    --teal:        #0AA0A0;
+    --teal-dark:   #088080;
+    --navy:        #0F2E4C;
+    --navy-soft:   #2A4866;
+    --gray-bg:     #F4F6F8;
+    --gray-card:   #FFFFFF;
+    --gray-line:   #E2E6EA;
+    --gray-text:   #4A5660;
+    --coral:       #E76F51;
+    --shadow:      0 1px 3px rgba(15,46,76,.07), 0 6px 24px rgba(15,46,76,.06);
+  }
+
+  * { box-sizing: border-box; }
+
+  html, body {
+    margin: 0;
+    padding: 0;
+    background: var(--gray-bg);
+    color: var(--navy);
+    font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, sans-serif;
+  }
+
+  a { color: var(--teal-dark); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+
+  /* ─── Header ─── */
+  header.topbar {
+    background: var(--gray-card);
+    border-bottom: 1px solid var(--gray-line);
+    padding: 14px 32px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  header.topbar .brand {
+    font-weight: 600;
+    letter-spacing: .3px;
+    color: var(--navy);
+    font-size: 16px;
+  }
+  header.topbar .brand .accent { color: var(--teal); }
+  header.topbar nav a {
+    margin-left: 22px;
+    font-size: 11.5px;
+    text-transform: uppercase;
+    letter-spacing: 1.4px;
+    font-weight: 600;
+    color: var(--navy-soft);
+  }
+  header.topbar nav a:hover { color: var(--teal-dark); text-decoration: none; }
+
+  /* ─── Hero ─── */
+  .hero {
+    position: relative;
+    background:
+      radial-gradient(800px 400px at 90% 110%, rgba(10,160,160,0.45), transparent 60%),
+      linear-gradient(110deg, #0F2E4C 0%, #11436B 55%, #0AA0A0 130%);
+    color: #fff;
+    padding: 56px 32px 64px;
+    overflow: hidden;
+  }
+  .hero h1 {
+    margin: 0 0 14px;
+    font-size: 38px;
+    line-height: 1.15;
+    font-weight: 600;
+    letter-spacing: -.2px;
+    max-width: 720px;
+  }
+  .hero p.sub {
+    margin: 0;
+    max-width: 720px;
+    font-size: 16.5px;
+    line-height: 1.55;
+    color: rgba(255,255,255,0.85);
+  }
+  .hero p.cite {
+    margin: 24px 0 0;
+    font-size: 13px;
+    color: rgba(255,255,255,0.65);
+    max-width: 720px;
+  }
+  .hero p.cite a { color: #B6E9E9; }
+  .hero svg.motif {
+    position: absolute;
+    right: -40px;
+    top: 30px;
+    width: 320px;
+    height: 280px;
+    opacity: 0.32;
+    pointer-events: none;
+  }
+
+  /* ─── Page sections ─── */
+  main {
+    max-width: 1080px;
+    margin: -32px auto 56px;
+    padding: 0 32px;
+    position: relative;
+  }
+  .card {
+    background: var(--gray-card);
+    border-radius: 12px;
+    box-shadow: var(--shadow);
+    padding: 28px 32px;
+    margin-bottom: 28px;
+  }
+  .card h2 {
+    margin: 0 0 18px;
+    font-size: 19px;
+    font-weight: 600;
+    color: var(--navy);
+  }
+  .card h2 .step {
+    display: inline-block;
+    background: var(--teal);
+    color: #fff;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 1px;
+    padding: 3px 8px 2px;
+    border-radius: 4px;
+    margin-right: 10px;
+    vertical-align: 2px;
+  }
+  .card h3 { margin: 22px 0 10px; font-size: 14px; font-weight: 600; color: var(--navy-soft); letter-spacing: .2px; }
+  .card p { color: var(--gray-text); margin: 0 0 12px; }
+
+  /* ─── Inputs ─── */
+  .two-col {
+    display: grid;
+    grid-template-columns: 1.05fr 1fr;
+    gap: 32px;
+  }
+  @media (max-width: 820px) { .two-col { grid-template-columns: 1fr; } }
+
+  label.field { display: block; margin-bottom: 14px; }
+  label.field > span {
+    display: block;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: .4px;
+    color: var(--navy-soft);
+    margin-bottom: 5px;
+    text-transform: uppercase;
+  }
+  label.field > .hint { display: block; font-size: 12px; font-weight: 400; color: var(--gray-text); margin-bottom: 6px; text-transform: none; letter-spacing: 0; }
+
+  input[type=text], input[type=number], textarea, select {
+    width: 100%;
+    padding: 8px 10px;
+    border: 1px solid var(--gray-line);
+    border-radius: 7px;
+    font-family: inherit;
+    font-size: 14px;
+    color: var(--navy);
+    background: #fff;
+    transition: border-color .12s, box-shadow .12s;
+  }
+  input[type=text]:focus, input[type=number]:focus, textarea:focus, select:focus {
+    outline: none;
+    border-color: var(--teal);
+    box-shadow: 0 0 0 3px rgba(10,160,160,.15);
+  }
+  textarea { font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace; font-size: 12.5px; resize: vertical; min-height: 110px; }
+
+  .row { display: flex; gap: 10px; align-items: center; }
+  .row > * { flex: 1; }
+  .row > .btn-secondary { flex: 0 0 auto; }
+
+  .btn {
+    display: inline-block;
+    padding: 10px 22px;
+    background: var(--teal);
+    color: #fff;
+    border: none;
+    border-radius: 24px;
+    font-family: inherit;
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: .3px;
+    cursor: pointer;
+    transition: background .12s, transform .04s;
+  }
+  .btn:hover:not(:disabled) { background: var(--teal-dark); }
+  .btn:active:not(:disabled) { transform: translateY(1px); }
+  .btn:disabled { background: #B7C2CD; cursor: not-allowed; }
+  .btn-secondary {
+    background: transparent;
+    color: var(--navy-soft);
+    border: 1px solid var(--gray-line);
+    padding: 7px 14px;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+  }
+  .btn-secondary:hover { background: var(--gray-bg); color: var(--navy); }
+  .btn-large { font-size: 15px; padding: 12px 32px; }
+
+  details.advanced {
+    margin-top: 8px;
+    border-top: 1px dashed var(--gray-line);
+    padding-top: 14px;
+  }
+  details.advanced > summary {
+    cursor: pointer;
+    font-size: 12.5px;
+    color: var(--teal-dark);
+    font-weight: 600;
+    letter-spacing: .3px;
+    margin-bottom: 12px;
+  }
+
+  /* ─── Ecology table ─── */
+  table.eco {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+  }
+  table.eco th, table.eco td {
+    padding: 6px 6px;
+    text-align: left;
+    border-bottom: 1px solid var(--gray-line);
+  }
+  table.eco th {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: .4px;
+    color: var(--navy-soft);
+    font-weight: 600;
+  }
+  table.eco input[type=text] { padding: 4px 6px; font-size: 13px; }
+  table.eco input[type=color] {
+    width: 32px; height: 28px;
+    padding: 0;
+    border: 1px solid var(--gray-line);
+    border-radius: 5px;
+    cursor: pointer;
+    background: none;
+  }
+  table.eco td.x { width: 36px; text-align: center; }
+  table.eco button.del { background: none; border: none; color: var(--gray-text); cursor: pointer; font-size: 16px; }
+  table.eco button.del:hover { color: var(--coral); }
+  .add-row { margin-top: 8px; }
+
+  /* ─── Progress ─── */
+  .progress-wrap { margin-top: 14px; display: none; }
+  .progress-wrap.active { display: block; }
+  .progress-bar {
+    height: 8px;
+    background: var(--gray-line);
+    border-radius: 999px;
+    overflow: hidden;
+  }
+  .progress-bar > div {
+    height: 100%;
+    background: linear-gradient(90deg, var(--teal), var(--teal-dark));
+    width: 0%;
+    transition: width .25s;
+  }
+  .progress-status {
+    font-size: 12.5px;
+    color: var(--gray-text);
+    margin-top: 8px;
+    font-family: ui-monospace, monospace;
+  }
+  .progress-status.error { color: var(--coral); }
+
+  /* ─── Results ─── */
+  .results { display: none; }
+  .results.active { display: block; }
+
+  .habitat-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    gap: 12px;
+    margin-top: 8px;
+  }
+  .habitat-card {
+    border: 1px solid var(--gray-line);
+    border-radius: 8px;
+    padding: 10px 12px;
+    background: #fff;
+  }
+  .habitat-card .hname {
+    font-size: 12.5px;
+    font-weight: 600;
+    color: var(--navy);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+  }
+  .habitat-card .swatch {
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
+    flex: 0 0 auto;
+  }
+  .habitat-card .bars { display: flex; height: 18px; border-radius: 3px; overflow: hidden; }
+  .habitat-card .bars > div { height: 100%; }
+  .habitat-card .legend { font-size: 10.5px; color: var(--gray-text); margin-top: 6px; line-height: 1.35; }
+
+  .stat-row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 18px;
+    margin-bottom: 18px;
+  }
+  .stat-box { padding: 14px 16px; background: var(--gray-bg); border-radius: 8px; }
+  .stat-box .label {
+    font-size: 11px;
+    color: var(--navy-soft);
+    text-transform: uppercase;
+    letter-spacing: .4px;
+    font-weight: 600;
+  }
+  .stat-box .value {
+    font-size: 24px;
+    font-weight: 600;
+    color: var(--navy);
+    margin-top: 4px;
+  }
+  .stat-box .value.small { font-size: 14px; font-family: ui-monospace, monospace; }
+
+  .download-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 10px;
+    margin-top: 12px;
+  }
+  .download-grid .btn-dl {
+    padding: 10px 14px;
+    border: 1px solid var(--gray-line);
+    border-radius: 8px;
+    background: #fff;
+    color: var(--navy);
+    font-size: 13px;
+    text-align: left;
+    cursor: pointer;
+    transition: border-color .12s, background .12s;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .download-grid .btn-dl:hover { border-color: var(--teal); background: rgba(10,160,160,0.04); }
+  .download-grid .btn-dl .fn { font-weight: 600; }
+  .download-grid .btn-dl .desc { font-size: 11.5px; color: var(--gray-text); }
+  .download-grid .btn-dl svg { flex: 0 0 auto; color: var(--teal); }
+
+  .zip-row { margin-top: 14px; }
+
+  /* ─── About / footer ─── */
+  .about ol { padding-left: 22px; }
+  .about ol li { margin-bottom: 6px; color: var(--gray-text); }
+  .about code {
+    background: var(--gray-bg);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 12.5px;
+  }
+
+  footer {
+    text-align: center;
+    padding: 28px 32px 40px;
+    font-size: 12.5px;
+    color: var(--gray-text);
+  }
+</style>
+</head>
+<body>
+
+<header class="topbar">
+  <div class="brand">AdaptML <span class="accent">·</span> SCELSE</div>
+  <nav>
+    <a href="#run">Run</a>
+    <a href="#about">About</a>
+    <a href="https://github.com/almlab/adaptml">Source</a>
+  </nav>
+</header>
+
+<section class="hero">
+  <h1>Partition phylogenies by ecology.</h1>
+  <p class="sub">AdaptML jointly infers ecological populations and their projected habitats from a phylogenetic tree annotated with environmental sample metadata. Run the full analysis in your browser; export modern iTOL datasets to reproduce Figure 1 of Hunt&nbsp;et&nbsp;al. (2008).</p>
+  <p class="cite">Hunt DE, David LA, Gevers D, Preheim SP, Alm EJ, Polz MF.<br>
+    <em>Resource Partitioning and Sympatric Differentiation Among Closely Related Bacterioplankton.</em>
+    <a href="https://www.science.org/doi/10.1126/science.1157890" target="_blank" rel="noopener">Science 320, 1081 (2008)</a>.</p>
+  <svg class="motif" viewBox="0 0 320 280" aria-hidden="true">
+    <g stroke="#fff" stroke-width="1.2" fill="none" stroke-linecap="round">
+      <path d="M30,140 L130,140"/>
+      <path d="M130,80 L130,200"/>
+      <path d="M130,80 L210,40"/><path d="M130,80 L210,120"/>
+      <path d="M130,200 L210,160"/><path d="M130,200 L210,240"/>
+      <path d="M210,40 L280,20"/><path d="M210,40 L280,60"/>
+      <path d="M210,120 L280,100"/><path d="M210,120 L280,140"/>
+      <path d="M210,160 L280,160"/><path d="M210,160 L280,180"/>
+      <path d="M210,240 L280,220"/><path d="M210,240 L280,260"/>
+    </g>
+    <g fill="#fff">
+      <circle cx="130" cy="80" r="4"/>
+      <circle cx="130" cy="200" r="4"/>
+      <circle cx="210" cy="40" r="3.5"/>
+      <circle cx="210" cy="120" r="3.5"/>
+      <circle cx="210" cy="160" r="3.5"/>
+      <circle cx="210" cy="240" r="3.5"/>
+    </g>
+  </svg>
+</section>
+
+<main>
+
+  <!-- ─── INPUT ─── -->
+  <section class="card" id="run">
+    <h2><span class="step">1</span>Input</h2>
+    <div class="two-col">
+      <div>
+        <label class="field">
+          <span>Phylogenetic tree (Newick)</span>
+          <span class="hint">Leaf names must follow <code>EcologyID_SequenceID</code> (e.g. <code>ZS_210</code>, <code>FF_91</code>).</span>
+          <div class="row">
+            <input type="file" id="tree-file" accept=".tree,.nwk,.txt,.newick" style="font-size: 12px;">
+            <button class="btn-secondary" id="load-example">Load vibrio.hsp60.tree</button>
+          </div>
+          <textarea id="tree-text" placeholder="((LeafA:0.1,LeafB:0.1):0.2,(LeafC:0.1,LeafD:0.1):0.2,Outgroup:0.5);"></textarea>
+        </label>
+
+        <label class="field">
+          <span>Outgroup leaf name</span>
+          <input type="text" id="outgroup" value="5S_OUTGROUP">
+        </label>
+
+        <details class="advanced" open>
+          <summary>Advanced parameters</summary>
+          <label class="field">
+            <span>Initial habitats (<code>init_hab_num</code>)</span>
+            <input type="number" id="init-hab-num" value="16" min="2" max="64" step="1">
+          </label>
+          <label class="field">
+            <span>Habitat-merge threshold (<code>collapse_thresh</code>)</span>
+            <input type="number" id="collapse-thresh" value="0.10" min="0.001" max="0.5" step="0.01">
+          </label>
+          <label class="field">
+            <span>EM convergence threshold (<code>converge_thresh</code>)</span>
+            <input type="number" id="converge-thresh" value="0.001" min="0.0001" max="0.1" step="0.001">
+          </label>
+          <label class="field">
+            <span>Empirical significance percentile</span>
+            <span class="hint">0.9999 reproduces the paper's p&nbsp;&lt;&nbsp;0.0001; 0.95 is faster for exploration.</span>
+            <input type="number" id="thresh-p" value="0.9999" min="0.5" max="0.9999" step="0.01">
+          </label>
+          <label class="field">
+            <span>Randomization iterations</span>
+            <span class="hint">Used to build the empirical null. 1000 ≈ 60&nbsp;s on the vibrio dataset; 10000 ≈ 10&nbsp;min.</span>
+            <input type="number" id="rand-iters" value="10000" min="0" max="10000" step="100">
+          </label>
+          <label class="field">
+            <span>Random seed (optional)</span>
+            <input type="number" id="seed" value="2727" placeholder="leave blank for non-deterministic">
+          </label>
+        </details>
+      </div>
+
+      <div>
+        <h3 style="margin-top: 0;">Ecology mapping</h3>
+        <p style="font-size:12.5px;">For each position in the <code>EcologyID</code>, list its possible characters and pick a display color. iTOL will render one colored ring per position.</p>
+        <table class="eco" id="eco-table">
+          <thead>
+            <tr><th>Pos</th><th>Char</th><th>Label</th><th>Color</th><th></th></tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+        <button class="btn-secondary add-row" id="add-eco-row">+ Add row</button>
+      </div>
+    </div>
+
+    <div style="margin-top: 24px; display: flex; align-items: center; gap: 14px;">
+      <button class="btn btn-large" id="run-btn">Run AdaptML</button>
+      <span style="font-size: 12.5px; color: var(--gray-text);">All computation runs locally in your browser — no upload.</span>
+    </div>
+
+    <div class="progress-wrap" id="progress-wrap">
+      <div class="progress-bar"><div id="progress-bar-fill"></div></div>
+      <div class="progress-status" id="progress-status">Idle.</div>
+    </div>
+  </section>
+
+  <!-- ─── RESULTS ─── -->
+  <section class="card results" id="results">
+    <h2><span class="step">2</span>Results</h2>
+
+    <div class="stat-row">
+      <div class="stat-box"><div class="label">Habitats</div><div class="value" id="stat-habitats">—</div></div>
+      <div class="stat-box"><div class="label">Significant populations</div><div class="value" id="stat-clusters">—</div></div>
+      <div class="stat-box"><div class="label">Transition rate μ</div><div class="value small" id="stat-mu">—</div></div>
+      <div class="stat-box"><div class="label">Joint log-likelihood</div><div class="value small" id="stat-lik">—</div></div>
+    </div>
+
+    <h3>Inferred habitats</h3>
+    <div class="habitat-grid" id="habitat-grid"></div>
+
+    <h3>Downloads — drop these on <a href="https://itol.embl.de/upload.cgi" target="_blank" rel="noopener">itol.embl.de</a></h3>
+    <div class="download-grid" id="download-grid"></div>
+    <div class="zip-row">
+      <button class="btn" id="download-zip">Download all (.zip)</button>
+    </div>
+  </section>
+
+  <!-- ─── ABOUT ─── -->
+  <section class="card about" id="about">
+    <h2><span class="step">i</span>About this analysis</h2>
+    <p>AdaptML builds a hidden Markov model on the phylogeny, treating habitat at each node as a latent state. An EM loop simultaneously (a) infers each habitat's emission distribution over the observed environmental categories and (b) updates the transition rate μ.</p>
+    <p>After convergence, a joint (Viterbi-style) assignment maps a single best habitat to every ancestral node. Subtrees rooted at habitat-transition nodes are then tested for significance against an empirical null produced by shuffling the leaf-environment labels.</p>
+
+    <h3>How to recreate Figure 1 of Hunt et al. (2008)</h3>
+    <ol>
+      <li>Click <strong>Load vibrio.hsp60.tree</strong>. The ecology table fills with the paper's color scheme (size fraction Z/5/1/F, season S/F).</li>
+      <li>Leave defaults at <code>init_hab_num&nbsp;=&nbsp;16</code>, <code>collapse_thresh&nbsp;=&nbsp;0.10</code>, <code>converge_thresh&nbsp;=&nbsp;0.001</code>. Bump <em>Empirical significance percentile</em> to <code>0.9999</code> and <em>Randomization iterations</em> to <code>10000</code> for publication-grade significance.</li>
+      <li>Click <strong>Run AdaptML</strong>. Watch the progress bar.</li>
+      <li>Click <strong>Download all (.zip)</strong>. Unzip locally.</li>
+      <li>At <a href="https://itol.embl.de/upload.cgi" target="_blank" rel="noopener">itol.embl.de</a>, upload <code>tree.nwk</code>. Then drag-and-drop each <code>dataset_*.txt</code> onto the iTOL canvas.</li>
+    </ol>
+
+    <h3>Algorithmic defaults</h3>
+    <p>All defaults match the original AdaptML code by Lawrence David (Alm Lab, MIT). The empirical p-value of 0.9999 plus 90&nbsp;% subtree-coherence cutoff reproduces the alternating blue/gray banding from the paper.</p>
+  </section>
+
+</main>
+
+<footer>
+  AdaptML · SCELSE port · ©&nbsp;2026.
+  Original code <a href="https://github.com/almlab/adaptml" target="_blank" rel="noopener">almlab/adaptml</a> by Lawrence David.
+</footer>
+
+<script>
+//═══════════════════════════════════════════════════════════════════════════
+// AdaptML — pure JavaScript port
+//═══════════════════════════════════════════════════════════════════════════
+//
+// Algorithm: faithful port of habitats/trunk/AdaptML.py + clusters/trunk/JointML.py
+// + clusters/getstats/rand_JointML.py + GetLikelihoods.py.
+//
+// Outputs: tree.nwk (rooted Newick with internal node IDs), modern iTOL datasets
+// (DATASET_COLORSTRIP per ecology position, DATASET_SYMBOLS for habitat circles,
+// DATASET_COLORSTRIP for the significant-cluster banding), habitats.json,
+// populations.tsv, stats.tsv, and a README.txt with iTOL instructions.
+
+//─── Seedable RNG (mulberry32) ─────────────────────────────────────────────
+function makeRng(seed) {
+  let s = (seed >>> 0) || (Math.random() * 0xffffffff) >>> 0;
+  return function() {
+    s = (s + 0x6D2B79F5) >>> 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+//─── Newick parser → unrooted tree ────────────────────────────────────────
+function speciesOf(name) {
+  // strip everything from the first '.' or '_' onward
+  const m = name.match(/^([^._]+)/);
+  return m ? m[0] : name;
+}
+
+let _NODE_ID = 0;
+function newNode(name) {
+  return {
+    id: _NODE_ID++,
+    name,
+    species: speciesOf(name),
+    perturb_species: speciesOf(name),
+    branches: [],          // list of branches (edges) incident to this node
+    isLeaf: false,
+    // ML scratch
+    ML_probs: new Map(),   // Map<neighborNode, {[habitat]: logProb}>
+    ML_path:  new Map(),   // Map<neighborNode, {[habitat]: bestKidHabitat}>
+    ML_state: null,        // {[habitat]: marginalProb}  OR  {[habitat]: bool} for Viterbi
+    sum_lik: 0,
+    // rooted-tree scratch
+    parent: null,
+    children: null,
+    leaf_nodes: null,      // descendant leaves (after rootify)
+    // habitat assignment (joint)
+    habitat: null,
+    likelihood: null,
+    threshold: null,
+    // cluster
+    cluster_root: false,
+    div_tested: false,
+    divergers: null,
+  };
+}
+function newBranch(length) {
+  return { length: Math.max(length, 0), immutable_length: Math.max(length, 0), ends: [] };
+}
+function attach(node, branch) {
+  branch.ends.push(node);
+  node.branches.push(branch);
+}
+
+// Tokeniser-style Newick parser. Produces an unrooted tree (returns an
+// arbitrary internal node + the tree object).
+function parseNewick(s) {
+  s = s.replace(/\s+/g, '');
+  // strip bootstraps of the form )NNN:  -> ):
+  s = s.replace(/\)[\d.]+:/g, '):');
+  if (!s.endsWith(';')) throw new Error('Newick must end with ;');
+  s = s.slice(0, -1);
+  let i = 0;
+  function parseSubtree() {
+    if (s[i] !== '(') return parseLeaf();
+    i++; // consume '('
+    const children = [parseSubtree()];
+    while (s[i] === ',') { i++; children.push(parseSubtree()); }
+    if (s[i] !== ')') throw new Error('expected ) at pos ' + i);
+    i++;
+    // optional internal label (bootstrap or name) then optional :length
+    let label = '';
+    while (i < s.length && s[i] !== ':' && s[i] !== ',' && s[i] !== ')' && s[i] !== ';') {
+      label += s[i++];
+    }
+    let length = 0;
+    if (s[i] === ':') {
+      i++;
+      let n = '';
+      while (i < s.length && /[\d.eE+-]/.test(s[i])) n += s[i++];
+      length = parseFloat(n);
+    }
+    return { children, label, length };
+  }
+  function parseLeaf() {
+    let name = '';
+    while (i < s.length && s[i] !== ':' && s[i] !== ',' && s[i] !== ')') name += s[i++];
+    let length = 0;
+    if (s[i] === ':') {
+      i++;
+      let n = '';
+      while (i < s.length && /[\d.eE+-]/.test(s[i])) n += s[i++];
+      length = parseFloat(n);
+    }
+    return { name, length };
+  }
+
+  _NODE_ID = 0;
+  const root = parseSubtree();
+  // Convert parsed AST → node/branch graph. Treat the parser's tree as rooted-but-arbitrary;
+  // we won't trust that root yet — the resulting graph is still topologically the unrooted tree.
+  const allNodes = [];
+  const allLeaves = [];
+
+  function build(astNode, parentBranch) {
+    let n;
+    if (astNode.children) {
+      n = newNode(astNode.label || '');
+      n.isLeaf = false;
+    } else {
+      n = newNode(astNode.name);
+      n.isLeaf = true;
+      allLeaves.push(n);
+    }
+    allNodes.push(n);
+    if (parentBranch) attach(n, parentBranch);
+    if (astNode.children) {
+      for (const c of astNode.children) {
+        const b = newBranch(c.length);
+        attach(n, b);
+        build(c, b);
+      }
+    }
+    return n;
+  }
+
+  // Build from the parsed AST without creating an extra "root" node when the AST root
+  // has >=3 children (truly unrooted Newick).
+  let entryNode;
+  if (root.children && root.children.length >= 3) {
+    entryNode = newNode('__entry__');
+    entryNode.isLeaf = false;
+    allNodes.push(entryNode);
+    for (const c of root.children) {
+      const b = newBranch(c.length);
+      attach(entryNode, b);
+      build(c, b);
+    }
+  } else {
+    entryNode = build(root, null);
+  }
+
+  return { entry: entryNode, allNodes, allLeaves };
+}
+
+//─── Per-direction leaf annotation (UnrootedLeaving equivalent) ─────────
+// At each internal node, for each incident branch direction, compute the
+// set of leaf-species reachable through that branch. Used to find the
+// outgroup branch.
+function annotateUnrooted(tree) {
+  for (const n of tree.allNodes) n._leafByNeighbor = new Map();
+
+  function leavesThrough(node, fromBranch) {
+    const neighbor = otherEnd(fromBranch, node);
+    if (node._leafByNeighbor.has(neighbor)) return node._leafByNeighbor.get(neighbor);
+    if (node.isLeaf) {
+      const rec = { species: [node.species], names: [node.name] };
+      node._leafByNeighbor.set(neighbor, rec);
+      return rec;
+    }
+    // gather across all OTHER branches
+    const species = [];
+    const names = [];
+    for (const b of node.branches) {
+      if (b === fromBranch) continue;
+      const child = otherEnd(b, node);
+      const r = leavesThrough(child, b);
+      // Wait: from child's perspective, the branch we came from is b — we want leaves on child's side.
+    }
+    // The recursion above is wrong; rewrite iteratively below.
+  }
+
+  // Simpler approach: do a 2-pass tree traversal rooted at any node.
+  // Pick a leaf as a temporary root. For each branch direction, leaves-through(node, branch) =
+  // union of leaves-through(neighbor, branch') for all branch' != branch incident to neighbor.
+  // Use memoization via a map keyed by branch + direction.
+  const memo = new Map(); // key "branchIdx|nodeId" -> {species[], names[]}
+
+  function key(branch, towardNode) {
+    return branch._idx + '|' + towardNode.id;
+  }
+  // Assign each branch an index
+  let bi = 0;
+  const allBranches = [];
+  for (const n of tree.allNodes) {
+    for (const b of n.branches) {
+      if (b._idx === undefined) { b._idx = bi++; allBranches.push(b); }
+    }
+  }
+
+  // leavesAcross(fromNode, throughBranch) = set of leaves reachable by going from fromNode along throughBranch and beyond.
+  function leavesAcross(fromNode, throughBranch) {
+    const toNode = otherEnd(throughBranch, fromNode);
+    const k = key(throughBranch, toNode);
+    if (memo.has(k)) return memo.get(k);
+    if (toNode.isLeaf) {
+      const rec = { species: [toNode.species], names: [toNode.name] };
+      memo.set(k, rec);
+      return rec;
+    }
+    const species = [];
+    const names = [];
+    for (const b of toNode.branches) {
+      if (b === throughBranch) continue;
+      const r = leavesAcross(toNode, b);
+      species.push(...r.species);
+      names.push(...r.names);
+    }
+    species.sort();
+    names.sort();
+    const rec = { species, names };
+    memo.set(k, rec);
+    return rec;
+  }
+
+  // For every node, for every neighbor (incident branch direction), store the leaf set on the OTHER side.
+  for (const n of tree.allNodes) {
+    for (const b of n.branches) {
+      const r = leavesAcross(n, b);
+      // n._leafByNeighbor maps neighbor -> leaves through that neighbor (i.e. on the other side of b)
+      const neighbor = otherEnd(b, n);
+      n._leafByNeighbor.set(neighbor, r);
+    }
+  }
+
+  // species_count: how many leaves per species
+  const species_count = {};
+  for (const l of tree.allLeaves) {
+    species_count[l.species] = (species_count[l.species] || 0) + 1;
+  }
+  tree.species_count = species_count;
+  tree.allBranches = allBranches;
+
+  return tree;
+}
+
+function otherEnd(branch, node) {
+  return branch.ends[0] === node ? branch.ends[1] : branch.ends[0];
+}
+
+//─── Rootify: find the outgroup branch, midpoint-root it ──────────────────
+function rootify(tree, outgroupName) {
+  // Find branch where the leaf-name set on one side is exactly [outgroupName].
+  let outBranch = null;
+  let outDir = null; // which end of the branch is the outgroup-side
+  for (const b of tree.allBranches) {
+    for (const end of b.ends) {
+      const neighbor = otherEnd(b, end);
+      const names = neighbor._leafByNeighbor.get(end).names;
+      if (names.length === 1 && names[0] === outgroupName) {
+        outBranch = b;
+        outDir = neighbor; // the outgroup leaf side
+        break;
+      }
+    }
+    if (outBranch) break;
+  }
+  if (!outBranch) throw new Error(`Outgroup '${outgroupName}' not found as a single-leaf branch.`);
+
+  // Insert a new root node mid-branch.
+  const root = newNode('__root__');
+  tree.allNodes.push(root);
+  const a = outBranch.ends[0];
+  const b = outBranch.ends[1];
+  // remove outBranch from a.branches and b.branches
+  a.branches = a.branches.filter(x => x !== outBranch);
+  b.branches = b.branches.filter(x => x !== outBranch);
+  // index of outBranch
+  const obi = tree.allBranches.indexOf(outBranch);
+  if (obi >= 0) tree.allBranches.splice(obi, 1);
+
+  // midpoint distance from leaf to each side (very approximate — just halve)
+  const half = outBranch.length / 2;
+  const ba = newBranch(half); attach(root, ba); attach(a, ba); ba._idx = tree.allBranches.length; tree.allBranches.push(ba);
+  const bb = newBranch(half); attach(root, bb); attach(b, bb); bb._idx = tree.allBranches.length; tree.allBranches.push(bb);
+
+  // Establish parent/child relationships from root
+  function imposeHierarchy(n, parent) {
+    n.parent = parent;
+    n.children = [];
+    for (const br of n.branches) {
+      const nb = otherEnd(br, n);
+      if (nb === parent) continue;
+      n.children.push(nb);
+      imposeHierarchy(nb, n);
+    }
+  }
+  imposeHierarchy(root, null);
+  tree.root = root;
+
+  // The "true root" = root's non-outgroup child (so that the outgroup hangs off as a single leaf).
+  let trueRoot = null;
+  for (const c of root.children) {
+    if (c.name !== outgroupName) trueRoot = c;
+  }
+  if (!trueRoot) throw new Error('outgroup is not directly under the new root');
+  tree.trueRoot = trueRoot;
+
+  // Build leaf_nodes list (post-order) for each rooted subtree under trueRoot.
+  function collectLeaves(n) {
+    if (n.isLeaf) { n.leaf_nodes = [n]; return [n]; }
+    n.leaf_nodes = [];
+    for (const c of n.children) n.leaf_nodes.push(...collectLeaves(c));
+    return n.leaf_nodes;
+  }
+  collectLeaves(trueRoot);
+
+  return tree;
+}
+
+//─── Likelihoods (sum-then-log) for habitat learning ─────────────────────
+// MLNode(node, kid, mu, M) computes node.ML_probs[kid][habitat] = log-likelihood
+// of the subtree rooted at kid (away from node), conditioned on node being in `habitat`.
+function MLNode_habitats(thisNode, kidNode, mu, M, habitats) {
+  if (thisNode.ML_probs.has(kidNode)) return;
+  const out = {};
+  thisNode.ML_probs.set(kidNode, out);
+  if (kidNode === null) {
+    const f = thisNode.species;
+    for (const h of habitats) out[h] = Math.log(M[h][f]);
+    return;
+  }
+  // child_nodes = kid's other neighbors (away from thisNode)
+  let childNodes = [];
+  for (const b of kidNode.branches) {
+    const nb = otherEnd(b, kidNode);
+    if (nb !== thisNode) childNodes.push(nb);
+  }
+  if (childNodes.length === 0) childNodes = [null, null];
+  if (childNodes.length === 1) childNodes.push(null);
+
+  MLNode_habitats(kidNode, childNodes[0], mu, M, habitats);
+  MLNode_habitats(kidNode, childNodes[1], mu, M, habitats);
+
+  // branch length between thisNode and kidNode
+  let t = 0;
+  for (const b of thisNode.branches) {
+    if (b.ends[0] === kidNode || b.ends[1] === kidNode) { t = b.length; break; }
+  }
+  const h = habitats.length;
+  const e = Math.exp(-h * mu * t);
+  const p_xx = 1.0 / h + (h - 1) / h * e;
+  const p_xy = 1.0 / h * (1 - e);
+
+  for (const thisH of habitats) {
+    let sumProb = Math.exp(-500);
+    for (const kidH of habitats) {
+      const trans = thisH === kidH ? p_xx : p_xy;
+      let prob = Math.log(trans);
+      if (childNodes[0] === null && childNodes[1] === null) {
+        prob += kidNode.ML_probs.get(null)[kidH];
+      } else {
+        prob += kidNode.ML_probs.get(childNodes[0])[kidH];
+        prob += kidNode.ML_probs.get(childNodes[1])[kidH];
+      }
+      sumProb += Math.exp(prob);
+    }
+    out[thisH] = Math.log(sumProb);
+  }
+}
+
+function learnLiks_habitats(tree, mu, M, habitats) {
+  // For each internal node, for each incident neighbor, compute ML_probs.
+  // Iterate by post-order so dependencies are filled.
+  // Use the entryNode as the recursion seed (we just need any internal node).
+  const internals = tree.allNodes.filter(n => !n.isLeaf);
+  for (const n of internals) {
+    for (const b of n.branches) {
+      const nb = otherEnd(b, n);
+      MLNode_habitats(n, nb, mu, M, habitats);
+    }
+  }
+}
+
+function estimateStates(node, M, habitats, visited) {
+  visited = visited || new Set();
+  if (visited.has(node)) return;
+  visited.add(node);
+  if (node.ML_probs.size === 1) {
+    // leaf: state = emission prob for its species (normalized)
+    const f = node.species;
+    const s = {};
+    let total = 0;
+    for (const h of habitats) { s[h] = M[h][f]; total += s[h]; }
+    for (const h of habitats) s[h] /= total;
+    node.ML_state = s;
+  } else {
+    const states = {};
+    for (const h of habitats) states[h] = 0;
+    for (const [kid, probs] of node.ML_probs) {
+      for (const h of habitats) states[h] += probs[h];
+    }
+    // softmax
+    let sumProb = 0;
+    for (const h of habitats) sumProb += Math.exp(states[h]);
+    const minFloat = Math.exp(-745);
+    if (sumProb < minFloat) sumProb = minFloat;
+    node.sum_lik = sumProb;
+    const s = {};
+    for (const h of habitats) s[h] = Math.exp(states[h]) / sumProb;
+    node.ML_state = s;
+  }
+  // recurse to neighbors
+  for (const b of node.branches) {
+    const nb = otherEnd(b, node);
+    if (!visited.has(nb)) estimateStates(nb, M, habitats, visited);
+  }
+}
+
+function learnMR(tree, M, mu, habitats, filters) {
+  // For each habitat, accumulate weighted contributions from each leaf.
+  // For each leaf with its parent's state, compute p_xy or p_xx and weight.
+  const newM = {};
+  for (const h of habitats) {
+    newM[h] = {};
+    for (const f of filters) newM[h][f] = Math.exp(-24);
+  }
+  const hn = habitats.length;
+  for (const leaf of tree.allLeaves) {
+    // find parent node and branch length
+    let parent = null, t = 0;
+    const b = leaf.branches[0];
+    parent = otherEnd(b, leaf);
+    t = b.length;
+    const e = Math.exp(-hn * mu * t);
+    const p_xx = 1.0 / hn + (hn - 1) / hn * e;
+    const p_xy = 1.0 / hn * (1 - e);
+    const f = leaf.species;
+    for (const ph of habitats) {
+      const pState = parent.ML_state[ph];
+      for (const lh of habitats) {
+        const tp = (ph === lh) ? p_xx : p_xy;
+        newM[lh][f] += tp * pState;
+      }
+    }
+  }
+  // normalize per habitat
+  for (const h of habitats) {
+    let scale = 0;
+    for (const f of filters) scale += newM[h][f];
+    for (const f of filters) newM[h][f] /= scale;
+  }
+  return newM;
+}
+
+function nodeRate(tree, habitats) {
+  // empirical estimate: for each internal-internal branch, compare max ML_state habitats.
+  let sameCount = 0;
+  let totalDist = 0;
+  let counter = 0;
+  for (const b of tree.allBranches) {
+    const a = b.ends[0], c = b.ends[1];
+    if (a.isLeaf || c.isLeaf) continue;
+    if (!a.ML_state || !c.ML_state) continue;
+    let mxA = -1, mxAst = null, mxC = -1, mxCst = null;
+    for (const h of habitats) {
+      if (a.ML_state[h] > mxA) { mxA = a.ML_state[h]; mxAst = h; }
+      if (c.ML_state[h] > mxC) { mxC = c.ML_state[h]; mxCst = h; }
+    }
+    if (mxAst === mxCst) sameCount++;
+    counter++;
+    totalDist += b.length;
+  }
+  if (counter === 0) return 0.1;
+  const hn = habitats.length;
+  const t = totalDist / counter;
+  const dist = 1 - sameCount / counter;
+  let inner = 1 - dist * hn / (hn - 1);
+  if (inner <= 0) inner = Math.exp(-10);
+  return -Math.log(inner) / (hn * t);
+}
+
+function checkConverge(tree, newM, oldM, habitats, filters) {
+  // mean abs diff
+  let diff = 0;
+  for (const h of habitats) {
+    for (const f of filters) {
+      diff += Math.abs(newM[h][f] - oldM[h][f]);
+    }
+  }
+  diff /= habitats.length * filters.length;
+  // total_prob (log-likelihood proxy)
+  let totalProb = 0, internalCount = 0, neighborTotal = 0;
+  for (const n of tree.allNodes) {
+    if (n.isLeaf) continue;
+    internalCount++;
+    let cnt = 0;
+    for (const [kid, p] of n.ML_probs) {
+      for (const h of habitats) totalProb += p[h];
+      cnt++;
+    }
+    neighborTotal = cnt;
+  }
+  if (internalCount && neighborTotal) totalProb /= internalCount * neighborTotal;
+  return { totalProb, diff };
+}
+
+function treeWipe(tree) {
+  for (const n of tree.allNodes) {
+    n.ML_probs = new Map();
+    n.ML_path = new Map();
+    n.ML_state = null;
+  }
+}
+
+//─── Habitat learning EM ──────────────────────────────────────────────────
+function adaptML(tree, opts, progress) {
+  const { init_hab_num, collapse_thresh, converge_thresh, rateopt, rng } = opts;
+  const filters = Object.keys(tree.species_count);
+  let habitats = [];
+  let M = {};
+  for (let i = 0; i < init_hab_num; i++) {
+    const h = 'habitat ' + i;
+    habitats.push(h);
+    const dist = {};
+    let scale = 0;
+    for (const f of filters) { dist[f] = rng(); scale += dist[f]; }
+    for (const f of filters) dist[f] /= scale;
+    M[h] = dist;
+  }
+  let mu = 1.00000000001;
+  const stats = [];
+
+  let outerIter = 0;
+  while (true) {
+    let counter = 0;
+    let diff = 1.0;
+    let oldDiff = 1.0;
+    let score = -9999.99999999;
+    while (true) {
+      stats.push({ outer: outerIter, counter, habs: habitats.length, score, mu, diff });
+      progress({ phase: 'em', outerIter, counter, habs: habitats.length, diff, mu });
+      treeWipe(tree);
+      learnLiks_habitats(tree, mu, M, habitats);
+      // seed estimateStates from any internal node
+      const seed = tree.allNodes.find(n => !n.isLeaf);
+      estimateStates(seed, M, habitats);
+      // M-step
+      const newM = learnMR(tree, M, mu, habitats, filters);
+      const newMu = nodeRate(tree, habitats);
+      const cc = checkConverge(tree, newM, M, habitats, filters);
+      score = cc.totalProb;
+      oldDiff = diff;
+      diff = cc.diff;
+      M = newM;
+      mu = newMu;
+      if (diff < converge_thresh) break;
+      // oscillation guard
+      const d1 = Math.floor(diff * 1e8);
+      const d2 = Math.floor(oldDiff * 1e8);
+      if (d1 > 0 && d1 === d2) break;
+      if (counter > 500) break;
+      counter++;
+    }
+    // collapse similar habitats by sum-of-squared-diff < collapse_thresh
+    const kept = {};
+    const keptOrder = [];
+    for (const h1 of habitats) {
+      let add = true;
+      for (const h2 of keptOrder) {
+        let s = 0;
+        for (const f of filters) { const d = M[h1][f] - kept[h2][f]; s += d * d; }
+        if (s < collapse_thresh) { add = false; break; }
+      }
+      if (add) { kept[h1] = M[h1]; keptOrder.push(h1); }
+    }
+    if (keptOrder.length === habitats.length) break;
+    habitats = keptOrder;
+    M = kept;
+    if (habitats.length < 2) break;
+    outerIter++;
+  }
+  return { habitats, M, mu, stats };
+}
+
+//─── Joint Viterbi assignment (after rootify) ─────────────────────────────
+// log-likelihood at each rooted node, using max instead of sum, with ML_path
+// for backtracking.
+function MLNode_joint(thisNode, kidNode, mu, M, habitats) {
+  if (thisNode.ML_probs.has(kidNode)) return;
+  const out = {};
+  const path = {};
+  thisNode.ML_probs.set(kidNode, out);
+  thisNode.ML_path.set(kidNode, path);
+  if (kidNode === null) {
+    const f = thisNode.species;
+    for (const h of habitats) out[h] = Math.log(M[h][f]);
+    return;
+  }
+  // child = kid's "other side" neighbors. In rooted form, that's kid's children (not the parent === thisNode).
+  let childNodes = (kidNode.children || []).filter(c => c !== thisNode);
+  if (childNodes.length === 0) childNodes = [null, null];
+  if (childNodes.length === 1) childNodes.push(null);
+
+  MLNode_joint(kidNode, childNodes[0], mu, M, habitats);
+  MLNode_joint(kidNode, childNodes[1], mu, M, habitats);
+
+  let t = 0;
+  for (const b of thisNode.branches) {
+    if (b.ends[0] === kidNode || b.ends[1] === kidNode) { t = b.length; break; }
+  }
+  const hn = habitats.length;
+  const e = Math.exp(-hn * mu * t);
+  const p_xx = 1.0 / hn + (hn - 1) / hn * e;
+  const p_xy = 1.0 / hn * (1 - e);
+
+  for (const thisH of habitats) {
+    let high = -Infinity, maxHab = null;
+    for (const kidH of habitats) {
+      const trans = thisH === kidH ? p_xx : p_xy;
+      let prob = Math.log(trans);
+      if (childNodes[0] === null && childNodes[1] === null) {
+        prob += kidNode.ML_probs.get(null)[kidH];
+      } else {
+        prob += kidNode.ML_probs.get(childNodes[0])[kidH];
+        prob += kidNode.ML_probs.get(childNodes[1])[kidH];
+      }
+      if (prob > high) { high = prob; maxHab = kidH; }
+    }
+    out[thisH] = high;
+    path[thisH] = maxHab;
+  }
+}
+
+function jointML(tree, M, mu, habitats) {
+  treeWipe(tree);
+  const trueRoot = tree.trueRoot;
+  for (const kid of trueRoot.children) {
+    MLNode_joint(trueRoot, kid, mu, M, habitats);
+  }
+  // pick best habitat at trueRoot
+  const scores = {};
+  for (const h of habitats) scores[h] = 0;
+  for (const kid of trueRoot.children) {
+    const probs = trueRoot.ML_probs.get(kid);
+    for (const h of habitats) scores[h] += probs[h];
+  }
+  let best = -Infinity, bestH = null;
+  for (const h of habitats) if (scores[h] > best) { best = scores[h]; bestH = h; }
+
+  function assign(node, maxHab) {
+    const state = {};
+    for (const h of habitats) state[h] = (h === maxHab);
+    node.ML_state = state;
+    node.habitat = maxHab;
+    if (!node.children || node.children.length === 0) return;
+    for (const kid of node.children) {
+      const kh = node.ML_path.get(kid)[maxHab];
+      assign(kid, kh);
+    }
+  }
+  assign(trueRoot, bestH);
+
+  // joint likelihood at each node = sum over child kids of ML_probs[kid][nodeHabitat]
+  function setLik(n) {
+    if (!n.children || n.children.length === 0) return;
+    let l = 0;
+    for (const c of n.children) {
+      l += n.ML_probs.get(c)[n.habitat];
+    }
+    n.likelihood = l;
+    for (const c of n.children) setLik(c);
+  }
+  setLik(trueRoot);
+
+  return best;
+}
+
+//─── Empirical thresholds via leaf-label shuffling ────────────────────────
+// For each random iter, shuffle leaf perturb_species, then constrained-Viterbi:
+// each node's habitat is FIXED (set by jointML on the real data), we only recompute
+// the joint log-likelihood given the shuffled emissions.
+function MLShuffle(thisNode, kidNode, mu, M, habitats) {
+  if (thisNode.ML_probs.has(kidNode)) return;
+  const out = {};
+  thisNode.ML_probs.set(kidNode, out);
+  const trueH = thisNode.habitat;
+  if (kidNode === null) {
+    const f = thisNode.perturb_species;
+    out[trueH] = Math.log(M[trueH][f]);
+    return;
+  }
+  let childNodes = (kidNode.children || []).filter(c => c !== thisNode);
+  if (childNodes.length === 0) childNodes = [null, null];
+  if (childNodes.length === 1) childNodes.push(null);
+  MLShuffle(kidNode, childNodes[0], mu, M, habitats);
+  MLShuffle(kidNode, childNodes[1], mu, M, habitats);
+
+  let t = 0;
+  for (const b of thisNode.branches) {
+    if (b.ends[0] === kidNode || b.ends[1] === kidNode) { t = b.length; break; }
+  }
+  const hn = habitats.length;
+  const e = Math.exp(-hn * mu * t);
+  const p_xx = 1.0 / hn + (hn - 1) / hn * e;
+  const p_xy = 1.0 / hn * (1 - e);
+  const kidH = kidNode.habitat;
+  let prob = (trueH === kidH) ? Math.log(p_xx) : Math.log(p_xy);
+  if (childNodes[0] === null && childNodes[1] === null) {
+    prob += kidNode.ML_probs.get(null)[kidH];
+  } else {
+    prob += kidNode.ML_probs.get(childNodes[0])[kidH];
+    prob += kidNode.ML_probs.get(childNodes[1])[kidH];
+  }
+  out[trueH] = prob;
+}
+
+function shuffleLeaves(tree, rng) {
+  const leaves = tree.allLeaves;
+  const speciesList = leaves.map(l => l.species);
+  // Fisher-Yates
+  for (let i = speciesList.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [speciesList[i], speciesList[j]] = [speciesList[j], speciesList[i]];
+  }
+  for (let i = 0; i < leaves.length; i++) leaves[i].perturb_species = speciesList[i];
+}
+
+// For each internal node, identify it by the two "first leaves" of its child subtrees
+// (matches the legacy GetALeaf(0)/GetALeaf(1) keying).
+function firstLeaf(node, side) {
+  if (node.isLeaf) return node;
+  return firstLeaf(node.children[side], side);
+}
+function pairKey(node) {
+  if (!node.children || node.children.length < 2) return null;
+  const l1 = firstLeaf(node.children[0], 0).name;
+  const l2 = firstLeaf(node.children[1], 1).name;
+  return l1 + ' ' + l2;
+}
+
+function runRandomizations(tree, M, mu, habitats, iters, threshP, rng, progress) {
+  const trueRoot = tree.trueRoot;
+  // collect every internal node (under trueRoot) that has 2+ children
+  const internalNodes = [];
+  function collect(n) {
+    if (!n.children || n.children.length < 2) return;
+    internalNodes.push(n);
+    for (const c of n.children) collect(c);
+  }
+  collect(trueRoot);
+
+  // empirical likelihoods per node, keyed by pairKey
+  const liks = new Map();
+  for (const n of internalNodes) liks.set(pairKey(n), []);
+
+  for (let it = 0; it < iters; it++) {
+    treeWipe(tree);
+    shuffleLeaves(tree, rng);
+    for (const kid of trueRoot.children) MLShuffle(trueRoot, kid, mu, M, habitats);
+    // for each internal node, joint log-lik for its assigned habitat
+    for (const n of internalNodes) {
+      let l = 0;
+      for (const c of n.children) {
+        l += n.ML_probs.get(c)[n.habitat];
+      }
+      liks.get(pairKey(n)).push(l);
+    }
+    if ((it & 31) === 0) progress({ phase: 'rand', it, iters });
+  }
+
+  // percentile threshold per node
+  const thresholds = new Map();
+  for (const [k, arr] of liks) {
+    arr.sort((a, b) => a - b);
+    const idx = Math.min(arr.length - 1, Math.max(0, Math.floor(arr.length * threshP)));
+    thresholds.set(k, arr[idx]);
+  }
+  return thresholds;
+}
+
+//─── Cluster identification ──────────────────────────────────────────────
+function findClusters(tree, thresholds, habitats) {
+  const trueRoot = tree.trueRoot;
+  // assign threshold per internal node
+  function setThresh(n) {
+    if (!n.children || n.children.length === 0) { n.threshold = 0; return; }
+    n.threshold = thresholds.get(pairKey(n)) || -Infinity;
+    for (const c of n.children) setThresh(c);
+  }
+  setThresh(trueRoot);
+
+  // Find divergence points: child.habitat !== node.habitat
+  // Then descend; if subtree is ≥90% homogeneous AND likelihood > threshold,
+  // mark as cluster_root. Otherwise descend further.
+  const clusters = [];
+
+  function tryCluster(node) {
+    if (!node.children || node.children.length === 0) return;
+    // homogeneity
+    let same = 0;
+    for (const leaf of node.leaf_nodes) {
+      // joint Viterbi already wrote ML_state[h]=bool per node, but only for trueRoot subtree.
+      // Leaf habitats are determined by the joint assignment too.
+      if (leaf.habitat === node.habitat) same++;
+    }
+    const frac = same / node.leaf_nodes.length;
+    let isCluster = false;
+    if (frac > 0.9) {
+      if (node.likelihood > node.threshold) isCluster = true;
+    }
+    if (isCluster) {
+      // Guard against the same node being added twice — happens because
+      // trueRoot.parent (the synthetic outgroup root) has no habitat,
+      // so trueRoot looks like a divergence point AND gets the explicit pass.
+      if (!node.cluster_root) {
+        node.cluster_root = true;
+        clusters.push(node);
+      }
+    } else {
+      for (const c of node.children) {
+        if (c.habitat === node.habitat) tryCluster(c);
+      }
+    }
+  }
+
+  // For every divergence point (post-order), recurse with tryCluster.
+  // Skip trueRoot here — its parent is the synthetic root, which would
+  // misfire as a divergence point. trueRoot is handled by the explicit pass below.
+  function findDivergence(n) {
+    if (!n.children || n.children.length === 0) return;
+    for (const c of n.children) findDivergence(c);
+    if (n !== trueRoot && n.parent && n.habitat !== n.parent.habitat) {
+      tryCluster(n);
+    }
+  }
+  findDivergence(trueRoot);
+  if (!clusters.includes(trueRoot)) tryCluster(trueRoot);
+
+  return clusters;
+}
+
+//─── Output writers ──────────────────────────────────────────────────────
+// Assign each internal node a unique ID (N00001…) for the rooted Newick.
+function assignInternalIds(tree) {
+  let i = 1;
+  function recur(n) {
+    if (n.isLeaf) return;
+    n.internalId = 'N' + String(i++).padStart(5, '0');
+    if (n.children) for (const c of n.children) recur(c);
+  }
+  recur(tree.trueRoot);
+}
+
+function writeNewick(tree) {
+  function rec(n) {
+    if (n.isLeaf) {
+      const len = n.parent ? branchBetween(n, n.parent).length : 0;
+      return n.name + ':' + len.toFixed(6);
+    }
+    const inner = n.children.map(rec).join(',');
+    const id = n.internalId || '';
+    const len = n.parent ? branchBetween(n, n.parent).length : 0;
+    return '(' + inner + ')' + id + ':' + len.toFixed(6);
+  }
+  function branchBetween(a, b) {
+    for (const br of a.branches) {
+      if (br.ends[0] === b || br.ends[1] === b) return br;
+    }
+    return { length: 0 };
+  }
+  return rec(tree.trueRoot) + ';';
+}
+
+function rgbToHex(r, g, b) {
+  const c = v => v.toString(16).padStart(2, '0');
+  return '#' + c(r) + c(g) + c(b);
+}
+
+// Build a palette for habitats — distinct hues, in order.
+function habitatColors(habitats) {
+  // base palette mimicking Hunt et al. Fig 1B; for >6 habitats interpolate.
+  const seed = [
+    [231, 76, 60],     // red
+    [46, 204, 113],    // green
+    [52, 152, 219],    // blue
+    [241, 196, 15],    // yellow
+    [230, 126, 34],    // orange
+    [142, 68, 173],    // purple
+    [22, 160, 133],    // teal
+    [44, 62, 80],      // dark
+  ];
+  const result = {};
+  habitats.forEach((h, i) => {
+    const c = seed[i % seed.length];
+    result[h] = rgbToHex(c[0], c[1], c[2]);
+  });
+  return result;
+}
+
+function writeColorstripDataset(label, leafColorMap, color) {
+  let s = 'DATASET_COLORSTRIP\n';
+  s += 'SEPARATOR COMMA\n';
+  s += 'DATASET_LABEL,' + label + '\n';
+  s += 'COLOR,' + (color || '#0AA0A0') + '\n';
+  s += 'STRIP_WIDTH,30\n';
+  s += 'MARGIN,1\n';
+  s += 'BORDER_WIDTH,0\n';
+  s += 'SHOW_INTERNAL,0\n';
+  s += 'DATA\n';
+  for (const [leaf, hex] of Object.entries(leafColorMap)) {
+    s += leaf + ',' + hex + '\n';
+  }
+  return s;
+}
+
+// TREE_COLORS range entries highlight entire clades — reproduces the Fig 1A
+// pie-sector banding shown as subtree blocks (alternating light blue / light gray),
+// each labeled with a population number (1, 2, 3, ...).
+// In iTOL, after upload, click the "Colored ranges" dataset and set
+// "Cover" to "Clade" (default in newer iTOL) and "Range cover style" to
+// "Solid color background" so each sector fills the full wedge.
+function writeTreeColorsDataset(clusters) {
+  let s = 'TREE_COLORS\n';
+  s += 'SEPARATOR TAB\n';
+  s += 'DATA\n';
+  clusters.forEach((c, i) => {
+    const color = (i % 2 === 0) ? '#B0D8E8' : '#D0D0D0';
+    const label = String(i + 1);
+    // Use internalId assigned to the cluster root node (embedded in tree.nwk)
+    s += c.internalId + '\t' + 'range' + '\t' + color + '\t' + label + '\n';
+  });
+  return s;
+}
+
+function writeMultibarDataset(label, fields, fieldColors, leafValues) {
+  let s = 'DATASET_MULTIBAR\n';
+  s += 'SEPARATOR COMMA\n';
+  s += 'DATASET_LABEL,' + label + '\n';
+  s += 'COLOR,#0AA0A0\n';
+  s += 'FIELD_LABELS,' + fields.join(',') + '\n';
+  s += 'FIELD_COLORS,' + fieldColors.join(',') + '\n';
+  s += 'WIDTH,150\n';
+  s += 'BORDER_WIDTH,0\n';
+  s += 'SHOW_INTERNAL,0\n';
+  s += 'DATA\n';
+  for (const [leaf, vals] of Object.entries(leafValues)) {
+    s += leaf + ',' + vals.join(',') + '\n';
+  }
+  return s;
+}
+
+function writeSymbolsDataset(label, entries) {
+  // entries: array of {id, size, color, shape, position}
+  let s = 'DATASET_SYMBOL\n';
+  s += 'SEPARATOR COMMA\n';
+  s += 'DATASET_LABEL,' + label + '\n';
+  s += 'COLOR,#0AA0A0\n';
+  s += 'MAXIMUM_SIZE,15\n';
+  s += 'DATA\n';
+  for (const e of entries) {
+    // ID,symbol,size,color,fill,position
+    // shapes: 1=square,2=circle,3=star,4=right triangle,5=left triangle,6=checkmark
+    s += [e.id, e.shape || 2, e.size || 10, e.color, 1, (e.position == null ? 0.5 : e.position)].join(',') + '\n';
+  }
+  return s;
+}
+
+function writeHabitatsJSON(habitats, M, colors) {
+  return JSON.stringify({
+    habitats: habitats.map(h => ({ name: h, color: colors[h], emission: M[h] }))
+  }, null, 2);
+}
+
+function writePopulationsTSV(clusters, habitatColors) {
+  let s = '#cluster_id\thabitat\tcolor\tleaf_count\tleaf_names\n';
+  clusters.forEach((c, i) => {
+    s += `C${String(i + 1).padStart(3, '0')}\t${c.habitat}\t${habitatColors[c.habitat]}\t${c.leaf_nodes.length}\t${c.leaf_nodes.map(l => l.name).join(';')}\n`;
+  });
+  return s;
+}
+
+function writeStatsTSV(stats) {
+  let s = 'outer_iter\tem_counter\thabs\tscore\tmu\tdiff\n';
+  for (const r of stats) {
+    s += [r.outer, r.counter, r.habs, r.score.toFixed(4), r.mu.toExponential(4), r.diff.toExponential(4)].join('\t') + '\n';
+  }
+  return s;
+}
+
+//─── Tiny uncompressed ZIP writer (STORED method, no deflate) ───────────
+function makeZip(files) {
+  // files: [{name, content (string or Uint8Array)}]
+  const enc = new TextEncoder();
+  const buffers = [];
+  const central = [];
+  let offset = 0;
+
+  function crc32(arr) {
+    // Lazy CRC32 (table init)
+    if (!crc32.table) {
+      const t = new Uint32Array(256);
+      for (let n = 0; n < 256; n++) {
+        let c = n;
+        for (let k = 0; k < 8; k++) c = (c & 1) ? (0xEDB88320 ^ (c >>> 1)) : (c >>> 1);
+        t[n] = c >>> 0;
+      }
+      crc32.table = t;
+    }
+    let c = 0xFFFFFFFF;
+    for (let i = 0; i < arr.length; i++) c = crc32.table[(c ^ arr[i]) & 0xFF] ^ (c >>> 8);
+    return (c ^ 0xFFFFFFFF) >>> 0;
+  }
+  function dosTime() {
+    const d = new Date();
+    const t = ((d.getHours() & 0x1F) << 11) | ((d.getMinutes() & 0x3F) << 5) | ((d.getSeconds() / 2) & 0x1F);
+    const dt = (((d.getFullYear() - 1980) & 0x7F) << 9) | (((d.getMonth() + 1) & 0x0F) << 5) | (d.getDate() & 0x1F);
+    return { t, dt };
+  }
+
+  for (const file of files) {
+    const data = typeof file.content === 'string' ? enc.encode(file.content) : file.content;
+    const nameBytes = enc.encode(file.name);
+    const crc = crc32(data);
+    const { t, dt } = dosTime();
+
+    // local file header
+    const local = new Uint8Array(30 + nameBytes.length);
+    const dv = new DataView(local.buffer);
+    dv.setUint32(0, 0x04034b50, true);  // signature
+    dv.setUint16(4, 20, true);           // version
+    dv.setUint16(6, 0, true);            // flags
+    dv.setUint16(8, 0, true);            // method = STORED
+    dv.setUint16(10, t, true);
+    dv.setUint16(12, dt, true);
+    dv.setUint32(14, crc, true);
+    dv.setUint32(18, data.length, true);
+    dv.setUint32(22, data.length, true);
+    dv.setUint16(26, nameBytes.length, true);
+    dv.setUint16(28, 0, true);
+    local.set(nameBytes, 30);
+
+    buffers.push(local);
+    buffers.push(data);
+
+    // central directory entry
+    const cd = new Uint8Array(46 + nameBytes.length);
+    const cdv = new DataView(cd.buffer);
+    cdv.setUint32(0, 0x02014b50, true);
+    cdv.setUint16(4, 20, true);
+    cdv.setUint16(6, 20, true);
+    cdv.setUint16(8, 0, true);
+    cdv.setUint16(10, 0, true);
+    cdv.setUint16(12, t, true);
+    cdv.setUint16(14, dt, true);
+    cdv.setUint32(16, crc, true);
+    cdv.setUint32(20, data.length, true);
+    cdv.setUint32(24, data.length, true);
+    cdv.setUint16(28, nameBytes.length, true);
+    cdv.setUint16(30, 0, true);
+    cdv.setUint16(32, 0, true);
+    cdv.setUint16(34, 0, true);
+    cdv.setUint16(36, 0, true);
+    cdv.setUint32(38, 0, true);
+    cdv.setUint32(42, offset, true);
+    cd.set(nameBytes, 46);
+    central.push(cd);
+
+    offset += local.length + data.length;
+  }
+
+  const cdStart = offset;
+  let cdSize = 0;
+  for (const c of central) { buffers.push(c); cdSize += c.length; }
+
+  // EOCD
+  const eocd = new Uint8Array(22);
+  const edv = new DataView(eocd.buffer);
+  edv.setUint32(0, 0x06054b50, true);
+  edv.setUint16(8, central.length, true);
+  edv.setUint16(10, central.length, true);
+  edv.setUint32(12, cdSize, true);
+  edv.setUint32(16, cdStart, true);
+  buffers.push(eocd);
+
+  return new Blob(buffers, { type: 'application/zip' });
+}
+
+//═══════════════════════════════════════════════════════════════════════════
+// Pipeline orchestration (runs on the main thread; algorithm above is heavy
+// but JS-only, so we yield control via Promise/setTimeout between phases).
+//═══════════════════════════════════════════════════════════════════════════
+
+async function runPipeline(input, progress) {
+  const { newick, outgroup, ecologyRows, init_hab_num, collapse_thresh, converge_thresh, thresh_p, rand_iters, seed } = input;
+  const rng = makeRng(seed || Math.floor(Math.random() * 1e9));
+
+  progress({ phase: 'parse', label: 'Parsing tree…' });
+  await yieldUI();
+  const tree = parseNewick(newick);
+
+  progress({ phase: 'annotate', label: 'Annotating tree (' + tree.allLeaves.length + ' leaves)…' });
+  await yieldUI();
+  annotateUnrooted(tree);
+
+  // ensure all branch lengths are > 0
+  const positive = tree.allBranches.map(b => b.length).filter(l => l > 0);
+  const minLen = positive.length ? Math.min(...positive) : 0.001;
+  for (const b of tree.allBranches) if (b.length <= 0) b.length = minLen;
+
+  progress({ phase: 'em', label: 'Learning habitats (EM)…' });
+  await yieldUI();
+  const { habitats, M, mu, stats } = adaptML(tree, {
+    init_hab_num, collapse_thresh, converge_thresh, rateopt: 'avg', rng
+  }, progress);
+
+  progress({ phase: 'rootify', label: 'Rooting tree at outgroup…' });
+  await yieldUI();
+  rootify(tree, outgroup);
+
+  progress({ phase: 'joint', label: 'Joint Viterbi habitat assignment…' });
+  await yieldUI();
+  const jointLik = jointML(tree, M, mu, habitats);
+
+  let clusters = [];
+  if (rand_iters > 0) {
+    progress({ phase: 'rand', label: 'Empirical null (' + rand_iters + ' shuffles)…' });
+    await yieldUI();
+    const thresholds = runRandomizations(tree, M, mu, habitats, rand_iters, thresh_p, rng, progress);
+
+    progress({ phase: 'cluster', label: 'Identifying significant populations…' });
+    await yieldUI();
+    // Re-run jointML to restore ML_probs for true (un-shuffled) leaves
+    for (const l of tree.allLeaves) l.perturb_species = l.species;
+    jointML(tree, M, mu, habitats);
+    clusters = findClusters(tree, thresholds, habitats);
+  }
+
+  return { tree, habitats, M, mu, stats, jointLik, clusters, ecologyRows };
+}
+
+function yieldUI() { return new Promise(r => setTimeout(r, 0)); }
+
+//═══════════════════════════════════════════════════════════════════════════
+// UI controller
+//═══════════════════════════════════════════════════════════════════════════
+
+const DEFAULT_ECO = [
+  { pos: 1, char: 'Z', label: 'Zooplankton (≥63 µm)', color: '#FF0000' },
+  { pos: 1, char: '5', label: 'Large particle (5–63 µm)', color: '#FF9664' },
+  { pos: 1, char: '1', label: 'Small particle (1–5 µm)', color: '#00FF00' },
+  { pos: 1, char: 'F', label: 'Free-living (<1 µm)', color: '#0000FF' },
+  { pos: 2, char: 'S', label: 'Spring', color: '#969696' },
+  { pos: 2, char: 'F', label: 'Fall', color: '#000000' },
+];
+
+function renderEcoTable(rows) {
+  const tbody = document.querySelector('#eco-table tbody');
+  tbody.innerHTML = '';
+  for (const row of rows) {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td><input type="number" min="1" max="8" value="${row.pos}" style="width:48px"></td>
+      <td><input type="text" maxlength="2" value="${row.char}" style="width:48px"></td>
+      <td><input type="text" value="${row.label}"></td>
+      <td><input type="color" value="${row.color}"></td>
+      <td class="x"><button class="del">×</button></td>
+    `;
+    tr.querySelector('button.del').onclick = () => { tr.remove(); };
+    tbody.appendChild(tr);
+  }
+}
+
+function readEcoTable() {
+  const rows = [];
+  for (const tr of document.querySelectorAll('#eco-table tbody tr')) {
+    const cells = tr.querySelectorAll('input');
+    rows.push({
+      pos: parseInt(cells[0].value, 10),
+      char: cells[1].value,
+      label: cells[2].value,
+      color: cells[3].value,
+    });
+  }
+  return rows;
+}
+
+function setProgress(pct, label, isError) {
+  document.querySelector('#progress-wrap').classList.add('active');
+  document.querySelector('#progress-bar-fill').style.width = pct + '%';
+  const ps = document.querySelector('#progress-status');
+  ps.textContent = label;
+  ps.classList.toggle('error', !!isError);
+}
+
+renderEcoTable(DEFAULT_ECO);
+
+document.querySelector('#add-eco-row').onclick = () => {
+  const rows = readEcoTable();
+  rows.push({ pos: 1, char: '', label: '', color: '#999999' });
+  renderEcoTable(rows);
+};
+
+document.querySelector('#tree-file').onchange = async (e) => {
+  const f = e.target.files[0];
+  if (!f) return;
+  const text = await f.text();
+  document.querySelector('#tree-text').value = text.trim();
+};
+
+document.querySelector('#load-example').onclick = async () => {
+  try {
+    const r = await fetch('./example/vibrio.hsp60.tree');
+    if (!r.ok) throw new Error('HTTP ' + r.status);
+    document.querySelector('#tree-text').value = (await r.text()).trim();
+    document.querySelector('#outgroup').value = '5S_OUTGROUP';
+    renderEcoTable(DEFAULT_ECO);
+  } catch (err) {
+    alert('Could not load example/vibrio.hsp60.tree.\n\nIf you opened this file directly with file://, your browser is blocking fetch(). Please serve the directory with:\n\npython3 -m http.server 8000\n\nthen open http://localhost:8000/adaptml.html\n\nDetail: ' + err.message);
+  }
+};
+
+let LAST_RESULT = null;
+let LAST_FILES = null;
+
+document.querySelector('#run-btn').onclick = async () => {
+  const newick = document.querySelector('#tree-text').value.trim();
+  if (!newick) { alert('Paste or load a Newick tree first.'); return; }
+  const outgroup = document.querySelector('#outgroup').value.trim();
+  if (!outgroup) { alert('Outgroup leaf name required.'); return; }
+
+  const input = {
+    newick,
+    outgroup,
+    ecologyRows: readEcoTable(),
+    init_hab_num: parseInt(document.querySelector('#init-hab-num').value, 10),
+    collapse_thresh: parseFloat(document.querySelector('#collapse-thresh').value),
+    converge_thresh: parseFloat(document.querySelector('#converge-thresh').value),
+    thresh_p: parseFloat(document.querySelector('#thresh-p').value),
+    rand_iters: parseInt(document.querySelector('#rand-iters').value, 10),
+    seed: parseInt(document.querySelector('#seed').value, 10) || 0,
+  };
+
+  document.querySelector('#run-btn').disabled = true;
+  document.querySelector('#results').classList.remove('active');
+  setProgress(2, 'Starting…', false);
+  const t0 = performance.now();
+
+  try {
+    const result = await runPipeline(input, (msg) => {
+      if (msg.phase === 'em') {
+        const habs = msg.habs != null ? msg.habs : '';
+        setProgress(15 + Math.min(35, (msg.counter || 0) * 3),
+          `EM · outer ${msg.outerIter || 0} · iter ${msg.counter || 0} · ${habs} habitats · diff ${msg.diff != null ? msg.diff.toExponential(2) : ''}`);
+      } else if (msg.phase === 'rand') {
+        const pct = msg.iters ? Math.round(70 + (msg.it / msg.iters) * 25) : 70;
+        setProgress(pct, `Randomization · ${msg.it}/${msg.iters}`);
+      } else if (msg.label) {
+        setProgress(10, msg.label);
+      }
+    });
+    setProgress(100, `Done in ${((performance.now() - t0) / 1000).toFixed(1)} s`);
+    LAST_RESULT = result;
+    renderResults(result);
+  } catch (err) {
+    console.error(err);
+    setProgress(100, 'Error: ' + err.message, true);
+  } finally {
+    document.querySelector('#run-btn').disabled = false;
+  }
+};
+
+function renderResults(result) {
+  const { tree, habitats, M, mu, jointLik, clusters, stats, ecologyRows } = result;
+  document.querySelector('#results').classList.add('active');
+  document.querySelector('#stat-habitats').textContent = habitats.length;
+  document.querySelector('#stat-clusters').textContent = clusters.length;
+  document.querySelector('#stat-mu').textContent = mu.toExponential(3);
+  document.querySelector('#stat-lik').textContent = jointLik.toFixed(2);
+
+  // Build habitat colors from inferred-emission-vector dominance: pick the
+  // dominant filter and use its mapping from the ecology table. This makes
+  // each habitat's swatch match its strongest environmental signal.
+  const hColors = habitatColors(habitats);
+  const ecoCharColors = {};
+  for (const r of ecologyRows) ecoCharColors[r.pos + ':' + r.char] = r.color;
+
+  const grid = document.querySelector('#habitat-grid');
+  grid.innerHTML = '';
+  const filters = Object.keys(M[habitats[0]]);
+  for (const h of habitats) {
+    const card = document.createElement('div');
+    card.className = 'habitat-card';
+    const dist = M[h];
+    // dominant filter
+    let bestF = filters[0], bestV = 0;
+    for (const f of filters) if (dist[f] > bestV) { bestV = dist[f]; bestF = f; }
+    card.innerHTML = `
+      <div class="hname"><span class="swatch" style="background:${hColors[h]}"></span>${h}</div>
+      <div class="bars"></div>
+      <div class="legend"></div>
+    `;
+    const bars = card.querySelector('.bars');
+    const legend = card.querySelector('.legend');
+    // colored bars per filter
+    const sorted = Object.entries(dist).sort((a, b) => b[1] - a[1]);
+    let legendStr = '';
+    for (const [f, v] of sorted) {
+      const c1 = ecoCharColors[`1:${f[0]}`] || '#888';
+      const c2 = ecoCharColors[`2:${f[1]}`] || '#444';
+      const bar = document.createElement('div');
+      bar.style.flex = String(v);
+      bar.style.background = `linear-gradient(90deg, ${c1} 0 50%, ${c2} 50% 100%)`;
+      bar.title = `${f} = ${(v * 100).toFixed(1)}%`;
+      bars.appendChild(bar);
+      if (v > 0.05) legendStr += `<span>${f}&nbsp;${(v * 100).toFixed(0)}%</span>&nbsp;&nbsp;`;
+    }
+    legend.innerHTML = legendStr;
+    grid.appendChild(card);
+  }
+
+  LAST_FILES = buildFiles(result);
+
+  const dl = document.querySelector('#download-grid');
+  dl.innerHTML = '';
+  for (const f of LAST_FILES) {
+    const b = document.createElement('button');
+    b.className = 'btn-dl';
+    b.innerHTML = `
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+      <div><div class="fn">${f.name}</div><div class="desc">${f.desc}</div></div>
+    `;
+    b.onclick = () => downloadFile(f.name, f.content);
+    dl.appendChild(b);
+  }
+}
+
+function buildFiles(result) {
+  const { tree, habitats, M, mu, jointLik, clusters, stats, ecologyRows } = result;
+  assignInternalIds(tree);
+
+  const hColors = habitatColors(habitats);
+
+  // colorstrip per ecology position
+  const positions = Array.from(new Set(ecologyRows.map(r => r.pos))).sort();
+  const ecoFiles = [];
+  for (const p of positions) {
+    const rowsAtP = ecologyRows.filter(r => r.pos === p);
+    const leafColorMap = {};
+    for (const l of tree.allLeaves) {
+      const c = l.species[p - 1];
+      const eco = rowsAtP.find(r => r.char === c);
+      leafColorMap[l.name] = eco ? eco.color : '#CCCCCC';
+    }
+    const label = `Ecology pos ${p}` + (rowsAtP[0] ? ` (${rowsAtP.map(r => r.char).join('/')})` : '');
+    ecoFiles.push({
+      name: `dataset_ecology_pos${p}.txt`,
+      desc: `Colorstrip per leaf for ecology position ${p}`,
+      content: writeColorstripDataset(label, leafColorMap, rowsAtP[0] ? rowsAtP[0].color : '#0AA0A0')
+    });
+  }
+
+  // habitat symbols at ancestral nodes (one per cluster root)
+  const symbolEntries = clusters.map(c => ({
+    id: c.internalId,
+    shape: 2,             // circle
+    size: 15,
+    color: hColors[c.habitat],
+    position: 0.5,
+  }));
+  const sym = writeSymbolsDataset('Inferred habitats', symbolEntries);
+
+  // clade-range highlights — TREE_COLORS format so each cluster appears as a
+  // highlighted subtree block in iTOL (matches Fig 1A), not an outer ring
+  const clusterStrip = writeTreeColorsDataset(clusters);
+
+  const files = [
+    { name: 'tree.nwk', desc: 'Rooted Newick tree with internal node IDs', content: writeNewick(tree) },
+    ...ecoFiles,
+    { name: 'dataset_habitat_symbols.txt', desc: 'Habitat circle at every cluster root', content: sym },
+    { name: 'dataset_population_strips.txt', desc: 'Alternating band per significant population', content: clusterStrip },
+    { name: 'habitats.json', desc: 'Learned emission probability matrix', content: writeHabitatsJSON(habitats, M, hColors) },
+    { name: 'populations.tsv', desc: 'Cluster members (one row per population)', content: writePopulationsTSV(clusters, hColors) },
+    { name: 'stats.tsv', desc: 'EM convergence log', content: writeStatsTSV(stats) },
+    { name: 'README.txt', desc: 'How to upload to iTOL', content: itolReadme() },
+  ];
+  return files;
+}
+
+function itolReadme() {
+  return `AdaptML output — uploading to iTOL
+====================================
+
+1. Go to https://itol.embl.de/upload.cgi
+2. Upload tree.nwk
+3. On the resulting tree page, drag-and-drop all dataset_*.txt files onto the canvas
+   (or use the Datasets tab → "Upload annotation files").
+4. In the iTOL controls, you can:
+   - Reorder datasets (Datasets tab)
+   - Toggle visibility per dataset
+   - Switch the tree to circular layout (Controls → Mode → Circular) to match
+     Fig 1A of Hunt et al. (2008).
+
+Files:
+  tree.nwk                          rooted Newick; internal nodes named N00001…
+  dataset_ecology_pos*.txt          per-position ecology strip (DATASET_COLORSTRIP)
+  dataset_habitat_symbols.txt       habitat circles at each significant cluster's root
+                                    (DATASET_SYMBOL — circle, color = habitat)
+  dataset_population_strips.txt     alternating bands per significant population
+                                    (DATASET_COLORSTRIP — blue/gray)
+  habitats.json                     learned emission distributions per habitat
+  populations.tsv                   strain membership per significant cluster
+  stats.tsv                         EM convergence log
+`;
+}
+
+function downloadFile(name, content) {
+  const blob = content instanceof Blob ? content : new Blob([content], { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = name;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+document.querySelector('#download-zip').onclick = () => {
+  if (!LAST_FILES) return;
+  const blob = makeZip(LAST_FILES);
+  downloadFile('adaptml_output.zip', blob);
+};
+</script>
+</body>
+</html>

--- a/clusters/getstats/GetLikelihoods.py
+++ b/clusters/getstats/GetLikelihoods.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # script to harvest empirical likelihoods from random trees and print
 # out % confidence boundaries
@@ -17,13 +17,13 @@ thresh = float(sys.argv[3])
 trees = glob.glob(emp_tree_d + "*")
 
 # where to write the results
-out_f = open(write_d + "/thresh.file",'w')
+out_f = open(write_d + "/thresh.file", 'w')
 lik_dict = {}
 
 for tree in trees:
 
     # open the likelihood file
-    lik_file = open(tree + "/lik.file",'r')
+    lik_file = open(tree + "/lik.file", 'r')
     lik_lines = lik_file.readlines()
 
     for line in lik_lines:
@@ -39,7 +39,7 @@ for tree in trees:
 # sort the likelihoods
 for leaves in lik_dict:
     lik_dict[leaves].sort()
-    perc = lik_dict[leaves][int(len(lik_dict[leaves])*thresh)]
+    perc = lik_dict[leaves][int(len(lik_dict[leaves]) * thresh)]
     # write out the results
     out_f.write(leaves + " " + str(perc) + "\n")
 

--- a/clusters/getstats/rand_JointML.py
+++ b/clusters/getstats/rand_JointML.py
@@ -1,23 +1,21 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # AdaptML
 
 import os
 import sys
+import math
 import pdb
 import time
 import random
 import glob
 
-from numpy.linalg import *
-from numpy.core import *
-from numpy.lib import *
 from numpy import *
 
 import rand_multitree as multitree
 import rand_ML as ML
 
 start_time = time.time()
-sys.setrecursionlimit(10000)
+sys.setrecursionlimit(50000)
 
 # potential variables:
 tree_fn = None
@@ -35,7 +33,7 @@ iter_limit = 10000
 
 # load inputs #
 inputs = sys.argv
-for ind in range(1,len(inputs)):
+for ind in range(1, len(inputs)):
     arg_parts = inputs[ind].split('=')
     code = arg_parts[0]
     arg = arg_parts[1]
@@ -53,7 +51,7 @@ for ind in range(1,len(inputs)):
         color_fn = arg
     elif code == 'write':
         write_dir = arg
-    elif code =='thresh':
+    elif code == 'thresh':
         thresh_fn = arg
     elif code == 'cdist':
         cdist = True
@@ -63,13 +61,13 @@ for ind in range(1,len(inputs)):
         iter_limit = int(arg)
 
 # load the parameters
-migration_file = open(migration_fn,'r')
+migration_file = open(migration_fn, 'r')
 migration_matrix = eval(migration_file.read())
-mu_file = open(mu_fn,'r')
+mu_file = open(mu_fn, 'r')
 mu = float(mu_file.read().strip())
 
 # build the tree #
-tree_file = open(tree_fn,"r")
+tree_file = open(tree_fn, "r")
 tree_string = tree_file.read().strip()
 tree = multitree.multitree()
 tree.build(tree_string)
@@ -95,7 +93,7 @@ if kids[0].name in outgroup:
     true_root = kids[1]
 else:
     true_root = kids[0]
-ML.LearnLiks(tree,mu,migration_matrix,true_root)
+ML.LearnLiks(tree, mu, migration_matrix, true_root)
 
 # estimate the states
 ML.EstimateStates(true_root)
@@ -103,7 +101,7 @@ ML.EstimateStates(true_root)
 # begin to generate the random data
 count = len(glob.glob(write_dir + "/*"))
 if count > 0:
-    print "write directory not empty; exiting"
+    print("write directory not empty; exiting")
     sys.exit(1)
 
 while count < iter_limit:
@@ -118,15 +116,15 @@ while count < iter_limit:
 
     # shuffle the tree's leaves
     tree.LeafShuffle()
-    
+
     # relearn the likelihoods using the new leaves and the old states
-    ML.LearnShuffleLiks(tree,mu,migration_matrix,true_root)
+    ML.LearnShuffleLiks(tree, mu, migration_matrix, true_root)
 
     # write out the likelihoods at each internal node
-    lik_file = open(dir_name + "lik.file",'w')
+    lik_file = open(dir_name + "lik.file", 'w')
     files = {}
     files['lik'] = lik_file
     true_root.PieCharts(files)
     lik_file.close()
-    
-    print float(count) / iter_limit
+
+    print(float(count) / iter_limit)

--- a/clusters/getstats/rand_ML.py
+++ b/clusters/getstats/rand_ML.py
@@ -5,29 +5,30 @@ import copy
 import math
 import pdb
 from numpy import *
-from numpy.matlib import *
 
-def CheckConvergence(tree,old_score,params):
+
+def CheckConvergence(tree, old_score, params):
 
     thresh = float(params[1])
 
     total_prob = 0
     for i in tree.internal_node_list:
         for j in i.ML_probs:
-            total_prob += sum(i.ML_probs[j].values())
+            total_prob += sum(list(i.ML_probs[j].values()))
 
-    total_prob /= len(tree.internal_node_list)*len(tree.species_count)
+    total_prob /= len(tree.internal_node_list) * len(tree.species_count)
 
     if abs(math.log(abs(old_score)) - math.log(abs(total_prob))) < thresh:
         return total_prob, 0
     else:
         return total_prob, 1
-        
+
+
 def EstimateStates(this_node):
 
     kids = this_node.GetKids()
     scores = {}
-    habitats = this_node.ML_probs.values()[0].keys()
+    habitats = list(list(this_node.ML_probs.values())[0].keys())
 
     for habitat in habitats:
         scores[habitat] = 0
@@ -36,7 +37,7 @@ def EstimateStates(this_node):
         for habitat in habitats:
             scores[habitat] += this_node.ML_probs[kid][habitat]
 
-    max_score = -sys.maxint
+    max_score = -sys.maxsize
     max_habitat = None
 
     for habitat in scores:
@@ -44,9 +45,10 @@ def EstimateStates(this_node):
             max_score = scores[habitat]
             max_habitat = habitat
 
-    AssignState(this_node,habitats,max_habitat)
+    AssignState(this_node, habitats, max_habitat)
 
-def AssignState(this_node,habitats,max_habitat):
+
+def AssignState(this_node, habitats, max_habitat):
 
     for habitat in habitats:
         if habitat is max_habitat:
@@ -57,19 +59,22 @@ def AssignState(this_node,habitats,max_habitat):
     kids = this_node.GetKids()
     for kid in kids:
         kid_habitat = this_node.ML_path[kid][max_habitat]
-        AssignState(kid,habitats,kid_habitat)
+        AssignState(kid, habitats, kid_habitat)
 
-def LearnLiks(tree,mu,migration_matrix,true_root):
 
-    true_kids = true_root.GetKids()
-    for kid in true_kids:
-        MLNode(true_root,kid,mu,migration_matrix)
-
-def LearnShuffleLiks(tree,mu,migration_matrix,true_root):
+def LearnLiks(tree, mu, migration_matrix, true_root):
 
     true_kids = true_root.GetKids()
     for kid in true_kids:
-        MLShuffleNode(true_root,kid,mu,migration_matrix)
+        MLNode(true_root, kid, mu, migration_matrix)
+
+
+def LearnShuffleLiks(tree, mu, migration_matrix, true_root):
+
+    true_kids = true_root.GetKids()
+    for kid in true_kids:
+        MLShuffleNode(true_root, kid, mu, migration_matrix)
+
 
 def TreeWipe(this_node):
 
@@ -82,17 +87,15 @@ def TreeWipe(this_node):
     for kid in this_node.GetKids():
         TreeWipe(kid)
 
-def MLNode(this_node,kid_node,mu,migration_matrix):
 
-    # no need to recurse if you've already solved this problem
+def MLNode(this_node, kid_node, mu, migration_matrix):
+
     if kid_node in this_node.ML_probs:
         return this_node.ML_probs[kid_node]
 
-    # if not ...
     this_node.ML_probs[kid_node] = {}
     this_node.ML_path[kid_node] = {}
 
-    # stop condition
     if kid_node is None:
         this_filter = this_node.species
         for this_habitat in migration_matrix:
@@ -101,12 +104,11 @@ def MLNode(this_node,kid_node,mu,migration_matrix):
             this_node.ML_probs[kid_node][this_habitat] = this_log
         return
 
-    # if not a leaf, need to obtain probabilities of child values:
-    child_nodes = filter(lambda i: i is not this_node, kid_node.other_nodes)
+    child_nodes = [i for i in kid_node.other_nodes if i is not this_node]
     if len(child_nodes) < 1:
-        child_nodes = [None,None]
-    MLNode(kid_node,child_nodes[0],mu,migration_matrix)
-    MLNode(kid_node,child_nodes[1],mu,migration_matrix)    
+        child_nodes = [None, None]
+    MLNode(kid_node, child_nodes[0], mu, migration_matrix)
+    MLNode(kid_node, child_nodes[1], mu, migration_matrix)
 
     t = None
     for branch in this_node.branch_list:
@@ -114,18 +116,17 @@ def MLNode(this_node,kid_node,mu,migration_matrix):
             t = branch.length
 
     hab_num = float(len(migration_matrix))
-    p_xx = 1.0/hab_num + (hab_num-1)/hab_num*math.exp(-hab_num*mu*t)
-    p_xy = 1.0/hab_num*(1-math.exp(-hab_num*mu*t)) 
+    p_xx = 1.0 / hab_num + (hab_num - 1) / hab_num * math.exp(-hab_num * mu * t)
+    p_xy = 1.0 / hab_num * (1 - math.exp(-hab_num * mu * t))
 
-    habitats = migration_matrix.keys()
+    habitats = list(migration_matrix.keys())
 
-    # for each of the current nodes possible states
     for this_habitat in habitats:
         sum_prob = math.exp(-500)
         probs = {}
-        
+
         for kid_habitat in habitats:
-            
+
             probs[kid_habitat] = 0
 
             if this_habitat is kid_habitat:
@@ -138,8 +139,7 @@ def MLNode(this_node,kid_node,mu,migration_matrix):
 
             probs[kid_habitat] += math.log(trans_prob)
 
-            # handle case at leaves
-            if child_nodes == [None,None]:
+            if child_nodes == [None, None]:
                 prob = kid_node.ML_probs[None][kid_habitat]
                 probs[kid_habitat] += prob
             else:
@@ -147,7 +147,7 @@ def MLNode(this_node,kid_node,mu,migration_matrix):
                 prob2 = kid_node.ML_probs[child_nodes[1]][kid_habitat]
                 probs[kid_habitat] += prob1 + prob2
 
-        high_prob = float(-sys.maxint)
+        high_prob = float(-sys.maxsize)
         max_hab = None
         for a_habitat in probs:
             if probs[a_habitat] > high_prob:
@@ -159,13 +159,12 @@ def MLNode(this_node,kid_node,mu,migration_matrix):
 
     return
 
-def MLShuffleNode(this_node,kid_node,mu,migration_matrix):
 
-    # no need to recurse if you've already solved this problem
+def MLShuffleNode(this_node, kid_node, mu, migration_matrix):
+
     if kid_node in this_node.ML_probs:
         return this_node.ML_probs[kid_node]
 
-    # if not ...
     this_node.ML_probs[kid_node] = {}
     this_node.ML_path[kid_node] = {}
 
@@ -174,7 +173,6 @@ def MLShuffleNode(this_node,kid_node,mu,migration_matrix):
         if this_node.true_state[habitat]:
             true_habitat = habitat
 
-    # stop condition
     if kid_node is None:
 
         perturb_filter = this_node.perturb_species
@@ -184,12 +182,11 @@ def MLShuffleNode(this_node,kid_node,mu,migration_matrix):
 
         return
 
-    # if not a leaf, need to obtain probabilities of child values:
-    child_nodes = filter(lambda i: i is not this_node, kid_node.other_nodes)
+    child_nodes = [i for i in kid_node.other_nodes if i is not this_node]
     if len(child_nodes) < 1:
-        child_nodes = [None,None]
-    MLShuffleNode(kid_node,child_nodes[0],mu,migration_matrix)
-    MLShuffleNode(kid_node,child_nodes[1],mu,migration_matrix)    
+        child_nodes = [None, None]
+    MLShuffleNode(kid_node, child_nodes[0], mu, migration_matrix)
+    MLShuffleNode(kid_node, child_nodes[1], mu, migration_matrix)
 
     t = None
     for branch in this_node.branch_list:
@@ -197,8 +194,8 @@ def MLShuffleNode(this_node,kid_node,mu,migration_matrix):
             t = branch.length
 
     hab_num = float(len(migration_matrix))
-    p_xx = 1.0/hab_num + (hab_num-1)/hab_num*math.exp(-hab_num*mu*t)
-    p_xy = 1.0/hab_num*(1-math.exp(-hab_num*mu*t)) 
+    p_xx = 1.0 / hab_num + (hab_num - 1) / hab_num * math.exp(-hab_num * mu * t)
+    p_xy = 1.0 / hab_num * (1 - math.exp(-hab_num * mu * t))
 
     # what's the kids habitat
     kid_habitat = None
@@ -206,7 +203,6 @@ def MLShuffleNode(this_node,kid_node,mu,migration_matrix):
         if kid_node.true_state[habitat]:
             kid_habitat = habitat
 
-    # for each of the current nodes possible states
     prob = 0
 
     if kid_habitat is true_habitat:
@@ -214,8 +210,7 @@ def MLShuffleNode(this_node,kid_node,mu,migration_matrix):
     else:
         prob += math.log(p_xy)
 
-    # if child
-    if child_nodes == [None,None]:
+    if child_nodes == [None, None]:
         prob += kid_node.ML_probs[None][kid_habitat]
     else:
         prob += kid_node.ML_probs[child_nodes[0]][kid_habitat]
@@ -224,4 +219,3 @@ def MLShuffleNode(this_node,kid_node,mu,migration_matrix):
     this_node.ML_probs[kid_node][true_habitat] = prob
 
     return
-

--- a/clusters/getstats/rand_branch.py
+++ b/clusters/getstats/rand_branch.py
@@ -1,48 +1,44 @@
-import copy;
+import copy
+
 
 class branch:
 
-    def __init__(self,length):
-        self.ends = []                  # nodes connected to
-        self.length = float(length)	# length (can change during rooting)
-        self.immutable_length = self.length # don't ever change this
-        self.visited = False            # used for traversing the tree
+    def __init__(self, length):
+        self.ends = []
+        self.length = float(length)
+        self.immutable_length = self.length
+        self.visited = False
 
     def __repr__(self):
+        if len(self.ends) == 2:
+            print_string = "(" + self.ends[0].name + ","
+            print_string += self.ends[1].name + "):" + str(self.immutable_length)
+        else:
+            print_string = ":" + str(self.immutable_length)
+        return print_string
 
-	if len(self.ends) == 2:
-	    print_string = "(" + self.ends[0].name + "," 
-	    print_string += self.ends[1].name + "):" + str(self.immutable_length)
-	else:
-	    print_string = ":" + str(self.immutable_length)
-	return print_string
-	
-    def addNode(self,node):
-	self.ends.append(node)
-	node.branch_list.append(self)
+    def addNode(self, node):
+        self.ends.append(node)
+        node.branch_list.append(self)
 
-    # recursion for finding all of the branches in an unrooted tree
-    def findBranches(self,all_branches):
-	
-	all_branches.append(self)
-	self.visited = True
+    def findBranches(self, all_branches):
 
-	for node in self.ends:
-	    for brch in node.branch_list:
-		if not brch.visited:
-		    all_branches = brch.findBranches(all_branches)
+        all_branches.append(self)
+        self.visited = True
 
-	return all_branches
+        for node in self.ends:
+            for brch in node.branch_list:
+                if not brch.visited:
+                    all_branches = brch.findBranches(all_branches)
 
-    # recusion to dump all the branches of an unrooted tree into the
-    # provided dictionary
-    def FillBranchDict(this_branch,branch_dict):
+        return all_branches
+
+    def FillBranchDict(this_branch, branch_dict):
 
         for parent_node in this_branch.ends:
             for branch in parent_node.branch_list:
                 if branch is not this_branch:
                     for child_node in branch.ends:
                         if child_node is not parent_node:
-                            print child_node
-                            print child_node.leaves
-            
+                            print(child_node)
+                            print(child_node.leaves)

--- a/clusters/getstats/rand_multitree.py
+++ b/clusters/getstats/rand_multitree.py
@@ -1,7 +1,5 @@
 # object class for construction of rooted and unrooted binary trees.
 #
-# my apologies - these data structures are terrible.
-#
 # lawrence david - ldavid@mit.edu - 2006.
 
 import re
@@ -16,27 +14,26 @@ from numpy import *
 import rand_node as node
 import rand_branch as branch
 
+
 class multitree:
-    
-    # recursive module for building unrooted trees from newick-notated
-    # strings.  
+
     def __init__(self):
-	self.build_queue = []
+        self.build_queue = []
         self.a_node = None
-	self.a_branch = None
-	self.root = None
-	self.root_branch = None
-	self.num_dups = 0
-	self.num_losses = 0
-	self.num_xfers = 0
-	self.event_queue = []           # keep running list of events
-	self.node_dict = dict()
-	self.mapping_hash = dict()      # store node mappings
-        self.loss_dict = {}             # cache res from countlosses
+        self.a_branch = None
+        self.root = None
+        self.root_branch = None
+        self.num_dups = 0
+        self.num_losses = 0
+        self.num_xfers = 0
+        self.event_queue = []
+        self.node_dict = dict()
+        self.mapping_hash = dict()
+        self.loss_dict = {}
         self.lca_dict = {}
         self.rec_dict = {}
-        self.leaf_count = 0             # how many leaves in tree
-        self.species_count = {}         # dict w/ counts of species
+        self.leaf_count = 0
+        self.species_count = {}
         self.internal_node_list = []
         self.leaf_node_list = []
         self.branch_list = []
@@ -45,30 +42,25 @@ class multitree:
         self.filters = None
         self.thresh_dict = {}
         self.base_colors = None
-        
-    # print the tree (intended for rooted trees)
+
     def __repr__(self):
-	if self.root == None:
-	    return "not rooted"
-	else:
-	    newickString = ""
-	    return self.root.treePrint(newickString)
-
-    # sneaky way of labeling probabilities - put them into the
-    # bootstraps 
-    def PrintLabeledBoots(self):
-
-        # rank the nodes according to their summed likelihoods
-        all_liks = array(map(lambda i: i.sum_lik,self.internal_node_list))
-        self.liks = all_liks
-
-        if self.root == None:
+        if self.root is None:
             return "not rooted"
         else:
             newickString = ""
-            return self.root.BootPrint(newickString,1)
+            return self.root.treePrint(newickString)
 
-    # get a list of species
+    def PrintLabeledBoots(self):
+
+        all_liks = array([i.sum_lik for i in self.internal_node_list])
+        self.liks = all_liks
+
+        if self.root is None:
+            return "not rooted"
+        else:
+            newickString = ""
+            return self.root.BootPrint(newickString, 1)
+
     def GetSpeciesDict(self):
         species_count = {}
 
@@ -81,59 +73,44 @@ class multitree:
         self.species_count = species_count
         return self.species_count
 
-    # hijack old build, so as to give opportunity to remove bootstraps
-    # ... 
-    def build(self,newick):
+    def build(self, newick):
 
-        # remove any bootstraps from newick
-        p = re.compile('\)[\d\.]+:')
-        # p = re.compile('\)\d+:')
-        newick = p.sub('):',newick)
-        self.RecursiveBuild(newick)  
+        p = re.compile(r'\)[\d\.]+:')
+        newick = p.sub('):', newick)
+        self.RecursiveBuild(newick)
 
-    def RecursiveBuild(self,newick):
+    def RecursiveBuild(self, newick):
 
-	# handle the case when you reach a trifurcating node (so
-	# unrooted), by looking for when you've got a stretch of 2
-	# colons unseparated by a parenthesis
-	colon_match1 = re.findall(':',newick)
-	colon_match2 = re.findall(':[^\)]*:[^\)]*:',newick)
+        colon_match1 = re.findall(':', newick)
+        colon_match2 = re.findall(r':[^\)]*:[^\)]*:', newick)
 
-	# if you reach a root
-	if len(colon_match1) == 1:
+        if len(colon_match1) == 1:
 
-	    root_node = self.build_queue[0]
-	    
-	    for kid_branches in root_node.branch_list:
-		root_node.child_branches.append(kid_branches)
+            root_node = self.build_queue[0]
 
-            # do rooted stuff
-	    self.root = root_node
-	    self.root.imposeHierarchy()
+            for kid_branches in root_node.branch_list:
+                root_node.child_branches.append(kid_branches)
+
+            self.root = root_node
+            self.root.imposeHierarchy()
             self.labelSubtrees()
             self.Get_Subnodes()
             self.root.Fill_Node_Dict()
 
-        # handle case of a tree with only 2 nodes:
         elif len(colon_match1) == 2:
 
-	    # find an innermost set of parentheses:
-            regex = re.search('\([^\(\)]*\)',newick).span()
-	    clade = newick[regex[0]+1:regex[1]-1]
+            regex = re.search(r'\([^\(\)]*\)', newick).span()
+            clade = newick[regex[0] + 1:regex[1] - 1]
 
-	    # split up the clade
-	    children = re.split(',',clade)
-	    son = children[0]
-	    daughter = children[1]
+            children = re.split(',', clade)
+            son = children[0]
+            daughter = children[1]
 
-            # build node1
             node1 = self.BuildNode(son)
             node2 = self.BuildNode(daughter)
 
-	    # unite the two nodes
-	    center_node = node1.unite(node2)
-            
-            # create a fake node:
+            center_node = node1.unite(node2)
+
             dummy_node = self.BuildNode("dummy_node:0.1")
             dummy_node.branch_list = []
             self.leaf_count -= 1
@@ -143,49 +120,34 @@ class multitree:
             self.a_node = dummy_node
             center_node.UnrootedLeaving()
 
-	# handle the trifurcating node of an unrooted tree
-	elif len(colon_match1) == 3 and len(colon_match2) > 0:
+        elif len(colon_match1) == 3 and len(colon_match2) > 0:
 
-            # note that this updated block can handle trees with leaf
-            # count >= 3
+            regex = re.search(r'\([^,]*,', newick).span()
+            first_leaf = newick[regex[0] + 1:regex[1] - 1]
 
-            # pull out the first node
-            regex = re.search('\([^,]*,',newick).span()
-            first_leaf = newick[regex[0]+1:regex[1]-1]
-
-            ####newick = re.sub(first_leaf + ',','',newick)
-            newick = newick.replace(first_leaf + ',','')
+            newick = newick.replace(first_leaf + ',', '')
 
             first_node = self.BuildNode(first_leaf)
 
-            # first_node.branch_list = []
-            # don't need to worry about clearing, since we'll be
-            # adding branches anyway later down in this block.
             self.build_queue.append(first_node)
 
-	    # join the last 2 nodes:
-            regex = re.search('\(.*,[^\)]*\);',newick).span()
-            clade = newick[regex[0]+1:regex[1]-2]
+            regex = re.search(r'\(.*,[^\)]*\);', newick).span()
+            clade = newick[regex[0] + 1:regex[1] - 2]
 
-            # split up the clade
-            children = re.split(',',clade)
+            children = re.split(',', clade)
             son = children[0]
             daughter = children[1]
 
-            # build two nodes and join
             node1 = self.BuildNode(son)
             node2 = self.BuildNode(daughter)
             center_node = node1.unite(node2)
 
-            # finally, join this new node with the remaining node:
             last_node = self.build_queue[0]
-            regex = re.search(':[^,]*,',newick).span()
+            regex = re.search(r':[^,]*,', newick).span()
             last_node.myBranch.addNode(center_node)
 
             self.a_branch = last_node.myBranch
 
-            # do some unrooted stuff, making sure you don't begin on a
-            # leaf. 
             if len(self.a_branch.ends[0].branch_list) == 3:
                 self.a_node = self.a_branch.ends[0]
                 self.a_branch.ends[0].UnrootedLeaving()
@@ -193,38 +155,30 @@ class multitree:
                 self.a_node = self.a_branch.ends[1]
                 self.a_branch.ends[1].UnrootedLeaving()
 
-	else:
+        else:
 
-	    # find an innermost set of parentheses:
-	    regex = re.search('\([^\(\)]*\):',newick).span()
-	    clade = newick[regex[0]+1:regex[1]-2]
+            regex = re.search(r'\([^\(\)]*\):', newick).span()
+            clade = newick[regex[0] + 1:regex[1] - 2]
 
-	    # split up the clade
-	    children = re.split(',',clade)
-	    son = children[0]
-	    daughter = children[1]
+            children = re.split(',', clade)
+            son = children[0]
+            daughter = children[1]
 
-            # build nodes and unite
             node1 = self.BuildNode(son)
             node2 = self.BuildNode(daughter)
-	    center_node = node1.unite(node2)
+            center_node = node1.unite(node2)
 
-	    # replace the matched string with the new node:
-	    new_newick = newick[0:regex[0]]
-	    new_newick += center_node.name
-	    new_newick += newick[regex[1]-1:]
+            new_newick = newick[0:regex[0]]
+            new_newick += center_node.name
+            new_newick += newick[regex[1] - 1:]
 
-	    # add the new node to the queue of extant nodes
-	    self.build_queue.append(center_node)
+            self.build_queue.append(center_node)
 
-	    # recurse
-	    self.RecursiveBuild(new_newick)
+            self.RecursiveBuild(new_newick)
 
-    # create a new node:
-    def BuildNode(this_tree,node_string):
-        splitSon = re.split(':',node_string)
+    def BuildNode(this_tree, node_string):
+        splitSon = re.split(':', node_string)
 
-        # see if anyone in the queue has the same name
         node1match = False
         for i in range(len(this_tree.build_queue)):
             if this_tree.build_queue[i].name == splitSon[0]:
@@ -233,62 +187,50 @@ class multitree:
                 node1match = True
                 break
         if node1match is not True:
-            node1 = node.node(splitSon[0],this_tree)
-            this_tree.leaf_count += 1   # another leaf added to tree 
+            node1 = node.node(splitSon[0], this_tree)
+            this_tree.leaf_count += 1
 
         node1.addBranch(splitSon[1])
 
         return node1
 
-    # label the subtrees
     def labelSubtrees(self):
+        if self.root is None:
+            print("you're trying to label an unrooted tree")
+        else:
+            self.root.subtreeLabel()
 
-	if self.root == None:
-	    print "you're trying to label an unrooted tree"
-	else:
-	    self.root.subtreeLabel()
-
-    # relabel the subtrees and rename nodes following transfer-induced
-    # shuffling
     def relabelSubtrees(self):
+        if self.root is None:
+            print("you're trying to label an unrooted tree")
+        else:
+            self.root.subtreeReLabel()
 
-	if self.root == None:
-	    print "you're trying to label an unrooted tree"
-	else:
-	    self.root.subtreeReLabel()
-
-
-    # get all subnodes (useful for finding LCAs)
     def Get_Subnodes(self):
-	self.root.Find_Subnodes()
+        self.root.Find_Subnodes()
 
-    def rootify(self,center_branch):
+    def rootify(self, center_branch):
 
-	# remember the old branch:
-	self.root_branch = center_branch
+        self.root_branch = center_branch
 
-	# create a new node
-	center_name = center_branch.ends[0].name
-	center_name += "-" + center_branch.ends[1].name
-	center_node = node.node(center_name,self)
-	self.root = center_node
-	
-	# give it children branches
-	child1 = branch.branch(center_branch.length/2)
-	child1.addNode(center_node)
-	child1.addNode(center_branch.ends[0])
-	child2 = branch.branch(center_branch.length/2)
-	child2.addNode(center_node)
-	child2.addNode(center_branch.ends[1])
-	center_node.child_branches.append(child1)
-	center_node.child_branches.append(child2)
+        center_name = center_branch.ends[0].name
+        center_name += "-" + center_branch.ends[1].name
+        center_node = node.node(center_name, self)
+        self.root = center_node
 
-	# erase the original branch from the child nodes branch_list
-	for kids in center_branch.ends:
-	    kids.branch_list.remove(center_branch)
+        child1 = branch.branch(center_branch.length / 2)
+        child1.addNode(center_node)
+        child1.addNode(center_branch.ends[0])
+        child2 = branch.branch(center_branch.length / 2)
+        child2.addNode(center_node)
+        child2.addNode(center_branch.ends[1])
+        center_node.child_branches.append(child1)
+        center_node.child_branches.append(child2)
 
-	# impose a hierarchy from the root
-	center_node.imposeHierarchy()
+        for kids in center_branch.ends:
+            kids.branch_list.remove(center_branch)
+
+        center_node.imposeHierarchy()
         self.labelSubtrees()
         self.Get_Subnodes()
         self.root.Fill_Node_Dict()
@@ -304,8 +246,7 @@ class multitree:
             rand_ind = random.random()
             shuffle_dict[rand_ind] = leaf
 
-        keys = shuffle_dict.keys()
-        keys.sort()
+        keys = sorted(shuffle_dict.keys())
 
         # swap in new species assignment
         for ind in range(len(leaves)):
@@ -314,4 +255,3 @@ class multitree:
             accep.perturb_species = donor.species
 
         return
-        

--- a/clusters/getstats/rand_node.py
+++ b/clusters/getstats/rand_node.py
@@ -2,73 +2,65 @@ import random
 import re
 import copy
 import sys
+import math
 import pdb
 
 from numpy import *
-from sets import Set
 
 import rand_branch as branch
 
+
 class node:
 
-    def __init__(self,name,arbre):
+    def __init__(self, name, arbre):
 
-        self.name_backup = name # argh, i need to refactor
+        self.name_backup = name
         self.name = name
 
-        # assign species names by stripping '.X' or '_X'
         match_str = re.compile(r'[\._]\w*-')
-        name = match_str.sub('-',name,0)
-        # catch trailers
+        name = match_str.sub('-', name, 0)
         match_str = re.compile(r'[\._]\w*')
-        species = match_str.sub('',name,0)
+        species = match_str.sub('', name, 0)
 
         self.species = species
         self.perturb_species = species
-	self.range = []
-	self.range.append(self.species)
+        self.range = []
+        self.range.append(self.species)
         self.tree = arbre
-	self.lca_scores = dict()        # keep track of lca scores
-	self.event_str = dict()         # keep track of events for each lca
-	    
-	# clear all of the other variables
-        self.myBranch = None            # used to construct unrooted trees
-	self.branch_list = []           # used to construct unrooted trees
-	self.child_branches = []        # list of branches to kids
-	self.parent_branch = []         # should have length 1
-        
-	self.subnodes = dict()          # all nodes below this
-	self.leaves = None              # leaves below this
+        self.lca_scores = dict()
+        self.event_str = dict()
+
+        self.myBranch = None
+        self.branch_list = []
+        self.child_branches = []
+        self.parent_branch = []
+
+        self.subnodes = dict()
+        self.leaves = None
         self.leaf_nodes = []
-        
-        # attach to each node a serial number, to tell nodes apart
-	#self.serial = random.randint(-sys.maxint,sys.maxint)
+
         self.serial = hash(self.name)
         self.newick_string = ""
         self.counts_dict = {}
         self.ancestors = []
 
-	self.visited = False            # useful for rooting trees
-        self.dup_count = 0              # number of duplications at this node
+        self.visited = False
+        self.dup_count = 0
 
-        # things for GetNodeLinkDict
         self.link_dict_visited = False
 
-        # things necessary for UnrootedLeaving
         self.leaf_dict = {}
-        self.name_dict = {}        
+        self.name_dict = {}
         self.branch_dict = {}
         self.unrooted_leaving_visited = False
         self.other_nodes = []
 
-        # stuff for global reconcile:
-        self.lca_lookups = {}  # store here 3 lookup tables, 1 for
-                               # each of the possible parents of this node
+        self.lca_lookups = {}
 
         # ML things
         self.ML_probs = {}
         self.ML_path = {}
-        self.ML_null_probs = {}        
+        self.ML_null_probs = {}
         self.ML_state = {}
         self.sum_lik = 0
 
@@ -79,50 +71,37 @@ class node:
         self.in_cluster = False
         self.is_rep = False
         self.prune_leaves = []
-        
+
     def __repr__(self):
-	#if self.myBranch == None:
-	#    return self.name
-	#else:	
-	#    return self.name + ":" + str(self.myBranch.length)
-        return self.name 
-    
-    def __eq__(self,other):
-	if self is None or other is None:
-	    return False
-	elif self.serial == other.serial:
-	    return True
-	else:
-	    return False
+        return self.name
 
-    def __ne__(self,other):
+    def __eq__(self, other):
+        if self is None or other is None:
+            return False
+        elif self.serial == other.serial:
+            return True
+        else:
+            return False
 
-	if self is None or other is None:
-	    return True
-	elif self.serial == other.serial:
-	    return False
-	else:
-	    return True
+    def __ne__(self, other):
+        if self is None or other is None:
+            return True
+        elif self.serial == other.serial:
+            return False
+        else:
+            return True
 
-    def __gt__(self,other):
-	if self.name > other.name:
-	    return True
-	else:
-	    return False
+    def __gt__(self, other):
+        return self.name > other.name
 
-    def __lt__(self,other):
-	if self.name < other.name:
-	    return True
-	else:
-	    return False
+    def __lt__(self, other):
+        return self.name < other.name
+
     def __hash__(self):
         return self.serial
 
     def isLeaf(self):
-	if len(self.child_branches) < 1:
-	    return True
-	else:
-	    return False
+        return len(self.child_branches) < 1
 
     def GetKids(self):
         kids = []
@@ -131,28 +110,25 @@ class node:
                 if j is not self:
                     kids.append(j)
         return kids
-	
+
     def PrintStates(this_node):
 
         if len(this_node.ML_state) > 0:
             if max(this_node.ML_state.values()) > 0:
 
-                print "node:",
-                node_name = this_node.treePrint("",0)
-                if node_name[0] is not "(":
-                    print "(" + node_name + ")"
+                print("node:", end=' ')
+                node_name = this_node.treePrint("", 0)
+                if node_name[0] != "(":
+                    print("(" + node_name + ")")
                 else:
-                    print node_name
-                print "prob:",
+                    print(node_name)
+                print("prob:", end=' ')
                 for state in this_node.ML_state:
-                    print state + ":", round(this_node.ML_state[state],3), 
-                print
+                    print(state + ":", round(this_node.ML_state[state], 3), end=' ')
+                print()
 
-                print "lik:", this_node.sum_lik
-                
-                #for state in this_node.ML_probs:
-                #    print state + ":", round(this_node.ML_probs[state],3), 
-                print
+                print("lik:", this_node.sum_lik)
+                print()
 
         for branch in this_node.child_branches:
             for kid_node in branch.ends:
@@ -165,14 +141,14 @@ class node:
 
         if this_node.tree.root is this_node:
             return parent
-        
+
         if len(this_node.parent_branch) > 0:
             for i in this_node.parent_branch[0].ends:
                 if i is not this_node:
                     parent = i
         return parent
-	
-    def SaveStates(this_node,perturb_log):
+
+    def SaveStates(this_node, perturb_log):
 
         if len(this_node.ML_state) > 0:
             if max(this_node.ML_state.values()) > 0:
@@ -188,235 +164,194 @@ class node:
                 if kid_node is not this_node:
                     kid_node.SaveStates(perturb_log)
 
+    def BootPrint(self, newickString, verbose=1):
 
+        count = 0
 
-    # recursively print out nodes
-    def BootPrint(self,newickString,verbose=1):
+        for kid_branches in self.child_branches:
+            for kid_nodes in kid_branches.ends:
+                if kid_nodes is not self:
+                    if count == 0:
+                        newickString += "("
+                        newickString = kid_nodes.BootPrint(newickString, verbose)
+                    else:
+                        newickString += ","
+                        newickString = kid_nodes.BootPrint(newickString, verbose)
+                        newickString += ")"
+                    count += 1
 
-	count = 0
-
-	for kid_branches in self.child_branches:
-	    for kid_nodes in kid_branches.ends:
-		if kid_nodes is not self:
-		    if count == 0:
-			newickString += "("
-			newickString = kid_nodes.BootPrint(newickString,verbose)
-		    else:
-			newickString += ","
-			newickString = kid_nodes.BootPrint(newickString,verbose)
-			newickString += ")"
-		    count += 1
-
-        # add ability to print state probabilities
         boot_str = ""
         if len(self.child_branches) > 1:
             if len(self.ML_state) > 0:
                 for i in self.ML_state:
                     boot_str += "|" + i + "|"
-                    boot_str += "-" + str(round(self.ML_state[i],3))
+                    boot_str += "-" + str(round(self.ML_state[i], 3))
 
         newickString += boot_str
 
         addString = ""
         if verbose:
             if len(self.parent_branch) > 0 and len(self.child_branches) == 0:
-                addString = self.name + ":" + str(self.parent_branch[0].length) 
-            elif len(self.parent_branch) > 0: 
+                addString = self.name + ":" + str(self.parent_branch[0].length)
+            elif len(self.parent_branch) > 0:
                 addString = ":" + str(self.parent_branch[0].length)
         else:
             if len(self.parent_branch) > 0 and len(self.child_branches) == 0:
-                addString = self.species + ":" + str(self.parent_branch[0].length) 
-            elif len(self.parent_branch) > 0: 
+                addString = self.species + ":" + str(self.parent_branch[0].length)
+            elif len(self.parent_branch) > 0:
                 addString = ":" + str(self.parent_branch[0].length)
 
-	return newickString + addString
-                
+        return newickString + addString
 
-    def addBranch(self,length):
+    def addBranch(self, length):
+        self.myBranch = branch.branch(length)
+        self.myBranch.addNode(self)
 
-	self.myBranch = branch.branch(length)
-	self.myBranch.addNode(self)
+    def treePrint(self, newickString, verbose=1):
 
-    # recursively print out nodes
-    def treePrint(self,newickString,verbose=1):
+        count = 0
 
-	count = 0
-
-	for kid_branches in self.child_branches:
-	    for kid_nodes in kid_branches.ends:
-		if kid_nodes is not self:
-		    if count == 0:
-			newickString += "("
-			newickString = kid_nodes.treePrint(newickString,verbose)
-		    else:
-			newickString += ","
-			newickString = kid_nodes.treePrint(newickString,verbose)
-			newickString += ")"
-		    count += 1
+        for kid_branches in self.child_branches:
+            for kid_nodes in kid_branches.ends:
+                if kid_nodes is not self:
+                    if count == 0:
+                        newickString += "("
+                        newickString = kid_nodes.treePrint(newickString, verbose)
+                    else:
+                        newickString += ","
+                        newickString = kid_nodes.treePrint(newickString, verbose)
+                        newickString += ")"
+                    count += 1
 
         addString = ""
 
         if verbose:
             if len(self.parent_branch) > 0 and len(self.child_branches) == 0:
-                addString = self.name + ":" + str(self.parent_branch[0].length) 
-            elif len(self.parent_branch) > 0: 
+                addString = self.name + ":" + str(self.parent_branch[0].length)
+            elif len(self.parent_branch) > 0:
                 addString = ":" + str(self.parent_branch[0].length)
         else:
             if len(self.parent_branch) > 0 and len(self.child_branches) == 0:
-                addString = self.name 
-	return newickString + addString
+                addString = self.name
+        return newickString + addString
 
-    # join two nodes in a central node
-    def unite(self,node2):
+    def unite(self, node2):
 
-	# create a new node
-	new_node_name = self.name + "-" + node2.name
-	center_node = node(new_node_name,self.tree)
-	self.myBranch.addNode(center_node)
-	node2.myBranch.addNode(center_node)
-	return center_node
+        new_node_name = self.name + "-" + node2.name
+        center_node = node(new_node_name, self.tree)
+        self.myBranch.addNode(center_node)
+        node2.myBranch.addNode(center_node)
+        return center_node
 
-    # recursively impose a hierarchy
     def imposeHierarchy(self):
 
-	# find all the child nodes that have yet to be visited and
-	# assign their children
-	for kid_branch in self.child_branches:
-	    for node in kid_branch.ends:
-		if not node.visited and node is not self:
-		    node.visited = True
-		    node.parent_branch.append(kid_branch)
-		    for child_branch in node.branch_list:
-			if child_branch is not kid_branch:
-			    node.child_branches.append(child_branch)
-			    node.imposeHierarchy()
+        for kid_branch in self.child_branches:
+            for node in kid_branch.ends:
+                if not node.visited and node is not self:
+                    node.visited = True
+                    node.parent_branch.append(kid_branch)
+                    for child_branch in node.branch_list:
+                        if child_branch is not kid_branch:
+                            node.child_branches.append(child_branch)
+                            node.imposeHierarchy()
 
-    # recursively label the roots of subtrees w/ the leaves contained
-    # below
     def subtreeLabel(self):
 
-	leaf_vec = []
-	
-	if self.leaves is not None:
-	    return self.leaves
+        leaf_vec = []
 
-	# recurse
+        if self.leaves is not None:
+            return self.leaves
+
         kids = self.GetKids()
         for kid in kids:
             child_leaves = kid.subtreeLabel()
             leaf_vec.extend(child_leaves)
 
-	# once you hit a leaf
-	if len(self.child_branches) == 0:
-	    leaf_vec.append(self.species)
+        if len(self.child_branches) == 0:
+            leaf_vec.append(self.species)
             self.leaf_nodes.append(self)
             self.prune_leaves.append(self)
         else:
             for kid in kids:
                 self.leaf_nodes.extend(kid.leaf_nodes)
                 self.prune_leaves.extend(kid.prune_leaves)
-                
-	# non-duplicates:
-	leaf_vec = dict(map(lambda i: (i,1),leaf_vec))
-	self.leaves = leaf_vec
-	return leaf_vec.keys()
 
-    # figure out which species tree node a gene tree node maps to
-    def subtreeMap(self,species_node):
-	
-	# do the children of the current species node possess the
-	# relevant genes?  if so, follow that child.  if not, return
-	# the current node
+        leaf_vec = dict(map(lambda i: (i, 1), leaf_vec))
+        self.leaves = leaf_vec
+        return list(leaf_vec.keys())
 
-	foundSet = 0
-	for kid_branches in species_node.child_branches:
-	    for kid_nodes in kid_branches.ends:
-		if kid_nodes is not species_node:
+    def subtreeMap(self, species_node):
 
-		    s_leaves = kid_nodes.leaves
-		    g_leaves = self.leaves
+        foundSet = 0
+        for kid_branches in species_node.child_branches:
+            for kid_nodes in kid_branches.ends:
+                if kid_nodes is not species_node:
 
-		    # count how many elements of the gene set of
-		    # leaves are not in the species set of leaves
+                    s_leaves = kid_nodes.leaves
+                    g_leaves = self.leaves
 
-		    n = 0
-		    for i in g_leaves.keys():
-			if not i in s_leaves:
-			    n += 1
-			    break
-		    
-		    # if you can see somewhere to descend, follow it
-		    if n == 0:
-			return self.subtreeMap(kid_nodes)
+                    n = 0
+                    for i in g_leaves.keys():
+                        if i not in s_leaves:
+                            n += 1
+                            break
 
-	# once you've run out of places to descend, just return
-	# wherever you've ended up:
-	return species_node
+                    if n == 0:
+                        return self.subtreeMap(kid_nodes)
 
-    # recursively store at each node a hash of all nodes below
+        return species_node
+
     def Find_Subnodes(self):
 
-	for kid_branches in self.child_branches:
-	    for kid_nodes in kid_branches.ends:
-		if kid_nodes is not self:
-		    new_dict = kid_nodes.Find_Subnodes()
-		    for k in new_dict.keys():
-			if not k in self.subnodes:
-			    self.subnodes[k] = 1
-		    # self.subnodes.extend(kid_nodes.Find_Subnodes())
+        for kid_branches in self.child_branches:
+            for kid_nodes in kid_branches.ends:
+                if kid_nodes is not self:
+                    new_dict = kid_nodes.Find_Subnodes()
+                    for k in new_dict.keys():
+                        if k not in self.subnodes:
+                            self.subnodes[k] = 1
 
-	# self.subnodes.append(self)
-	self.subnodes[self.species] = 1
-	return self.subnodes
+        self.subnodes[self.species] = 1
+        return self.subnodes
 
-    # find the last common ancestor of two nodes.  will descend from
-    # the subroot (self) looking to see which children possess both
-    # nodes.  if neither children possess both nodes, return current
-    # node
-
-    def Find_LCA(self,node1,node2):
+    def Find_LCA(self, node1, node2):
 
         for kid_branches in self.child_branches:
             for kid_nodes in kid_branches.ends:
                 if kid_nodes is not self:
                     if node1.species in kid_nodes.subnodes:
                         if node2.species in kid_nodes.subnodes:
-                            return kid_nodes.Find_LCA(node1,node2)
+                            return kid_nodes.Find_LCA(node1, node2)
         return self
 
-    # get list of all vertices in a tree
     def Fill_Node_Dict(vertex):
-	
-	# vertex.tree.node_dict[vertex.name] = vertex
+
         vertex.tree.node_dict[vertex.name] = vertex
 
-	for kid_branches in vertex.child_branches:
-	    for kid_nodes in kid_branches.ends:
-		if kid_nodes is not vertex:
-		    kid_nodes.Fill_Node_Dict()
+        for kid_branches in vertex.child_branches:
+            for kid_nodes in kid_branches.ends:
+                if kid_nodes is not vertex:
+                    kid_nodes.Fill_Node_Dict()
 
-    # initialize hash tables for lca scores for each node
-    def Init_LCA_Scores(vertex,node_dict):
+    def Init_LCA_Scores(vertex, node_dict):
 
-	for tnode in node_dict:
-	    vertex.lca_scores[tnode.name] = node.maxInt
+        for tnode in node_dict:
+            vertex.lca_scores[tnode.name] = node.maxInt
 
-	for kid_branches in vertex.child_branches:
-	    for kid_nodes in kid_branches.ends:
-		if kid_nodes is not vertex:
-		    kid_nodes.Init_LCA_Scores(node_dict)
+        for kid_branches in vertex.child_branches:
+            for kid_nodes in kid_branches.ends:
+                if kid_nodes is not vertex:
+                    kid_nodes.Init_LCA_Scores(node_dict)
 
-    # determine if one node is descended from the other ...
-    def Are_Related(node1,node2):
+    def Are_Related(node1, node2):
 
-	verdict = False
-	for e in node1.leaves.keys():
-	    if e in node2.leaves:
-		verdict = True
+        verdict = False
+        for e in node1.leaves.keys():
+            if e in node2.leaves:
+                verdict = True
 
-	return verdict
+        return verdict
 
-    # method to list all the leaves of this node, keyed by the parent
     def UnrootedLeaving(this_node):
 
         for branches in this_node.branch_list:
@@ -426,27 +361,23 @@ class node:
         this_node.tree.internal_node_list.append(this_node)
         other_nodes = this_node.GetOtherNodes()
 
-        # get leaves in each direction
         for parent_node in other_nodes:
 
-            child_nodes = list(Set(other_nodes).difference(Set([parent_node])))
-            this_node.GetChildLeaves(parent_node,child_nodes)
+            child_nodes = list(set(other_nodes).difference({parent_node}))
+            this_node.GetChildLeaves(parent_node, child_nodes)
 
-        # when done, move on to neighboring nodes:
         for node in other_nodes:
 
-            if len(node.leaf_dict) is not len(node.branch_list):
+            if len(node.leaf_dict) != len(node.branch_list):
                 node.UnrootedLeaving()
-                
-    def GetLeaves(this_node,parent_node):
 
-        # if the leaf dict has already been defined:
+    def GetLeaves(this_node, parent_node):
+
         if parent_node in this_node.leaf_dict:
             return this_node.leaf_dict[parent_node], this_node.name_dict[parent_node]
 
-        # if is a leaf
         if len(this_node.branch_list) < 2:
-            
+
             this_node.tree.leaf_node_list.append(this_node)
 
             if this_node.species in this_node.tree.species_count:
@@ -455,16 +386,16 @@ class node:
                 this_node.tree.species_count[this_node.species] = 1
 
             this_node.leaf_dict[parent_node] = [this_node.species]
-            this_node.name_dict[parent_node] = [this_node.name]          
+            this_node.name_dict[parent_node] = [this_node.name]
             return this_node.leaf_dict[parent_node], this_node.name_dict[parent_node]
 
         other_nodes = this_node.GetOtherNodes()
-        child_nodes = list(Set(other_nodes).difference(Set([parent_node])))
-        this_node.GetChildLeaves(parent_node,child_nodes)
-            
+        child_nodes = list(set(other_nodes).difference({parent_node}))
+        this_node.GetChildLeaves(parent_node, child_nodes)
+
         return this_node.leaf_dict[parent_node], this_node.name_dict[parent_node]
 
-    def GetChildLeaves(this_node,parent_node,other_nodes):
+    def GetChildLeaves(this_node, parent_node, other_nodes):
 
         merge_list = []
         name_list = []
@@ -475,7 +406,7 @@ class node:
                     continue
 
             kid_leaves, kid_names = kid_node.GetLeaves(this_node)
-            
+
             if type(kid_leaves[0]) is not type(''):
                 merge_list.extend(kid_leaves[0])
                 name_list.extend(kid_names[0])
@@ -483,7 +414,6 @@ class node:
                 merge_list.extend(kid_leaves)
                 name_list.extend(kid_names)
 
-            # this is a total hack
             this_node.leaf_dict[parent_node] = []
             this_node.name_dict[parent_node] = []
 
@@ -492,7 +422,7 @@ class node:
         this_node.leaf_dict[parent_node].extend(merge_list)
         this_node.name_dict[parent_node].extend(name_list)
 
-    def GetNodeLinkDict(this_node,node_link_dict):
+    def GetNodeLinkDict(this_node, node_link_dict):
 
         this_node.link_dict_visited = True
         leaf_dict = this_node.leaf_dict
@@ -503,27 +433,23 @@ class node:
             if type(subleaves[0]) == type([]):
                 subleaves = subleaves[0]
             sub_str = repr(subleaves)
-            
-            if sub_str in node_link_dict:
-                node_link_dict[sub_str].append((this_node,key))
-            else:
-                node_link_dict[sub_str] = [(this_node,key)]
-            # node_link_dict[sub_str] = (this_node,key)
 
-        # after that's been done, decide where to recurse
+            if sub_str in node_link_dict:
+                node_link_dict[sub_str].append((this_node, key))
+            else:
+                node_link_dict[sub_str] = [(this_node, key)]
+
         for relative in leaf_dict:
 
-            relative_keys = relative.leaf_dict.keys()
+            relative_keys = list(relative.leaf_dict.keys())
             subleaves = relative.leaf_dict[relative_keys[0]]
             subleaves.sort()
 
             if not relative.link_dict_visited:
                 relative.GetNodeLinkDict(node_link_dict)
 
-    # return a list of all bordering nodes
     def GetOtherNodes(this_node):
 
-        # fill out the leaf dictionary
         other_nodes = []
         for branch in this_node.branch_list:
             for node in branch.ends:
@@ -534,36 +460,31 @@ class node:
 
         return other_nodes
 
-    # get the distance between two nodes:
-    # call as follows:
-    # found, dist = node1.DistTo(node2)
-    def DistTo(this_node,that_node,this_branch=None,dist=0):
+    def DistTo(this_node, that_node, this_branch=None, dist=0):
 
-        # what to do at the end
         if this_node is that_node:
             return True, dist
 
-        # if not ...
         was_found = False
         found_dist = dist
         for i in this_node.branch_list:
             if i is not this_branch:
                 for j in i.ends:
                     if j is not this_node:
-                        found, new_dist = j.DistTo(that_node,i,dist+i.immutable_length)
+                        found, new_dist = j.DistTo(that_node, i, dist + i.immutable_length)
                         if found is True:
                             was_found = found
                             found_dist = new_dist
 
         return was_found, found_dist
-        
+
     def NodeWipe(this_node):
 
         for kid_branches in this_node.child_branches:
             for kid_nodes in kid_branches.ends:
                 if kid_nodes is not this_node:
                     kid_nodes.NodeWipe()
-                        
+
         this_node.child_branches = []
         this_node.parent_branch = []
         this_node.subnodes = {}
@@ -571,7 +492,7 @@ class node:
         this_node.ML_state = {}
         this_node.ML_probs = {}
 
-    def LearnMR(this_node,MR_matrix,species_key):
+    def LearnMR(this_node, MR_matrix, species_key):
 
         if len(this_node.branches) < 1:
             pdb.set_trace()
@@ -579,10 +500,10 @@ class node:
         for i in this_node.child_branches:
             for j in i.ends:
                 if j is not this_node:
-                    j.LearnMR(MR_matrix,species_key)
-        
+                    j.LearnMR(MR_matrix, species_key)
+
     # code to produce pie charts at internal nodes
-    def PieCharts(this_node,files):
+    def PieCharts(this_node, files):
 
         kids = this_node.GetKids()
         if len(kids) < 2:
@@ -606,17 +527,16 @@ class node:
         for kid in kids:
             this_lik += this_node.ML_probs[kid][true_habitat]
 
-        # find nodes to define this subtree
         node1 = this_node.GetALeaf(0)
-        node2 = this_node.GetALeaf(1)                
+        node2 = this_node.GetALeaf(1)
 
-        lik_str  = str(node1) + " "
+        lik_str = str(node1) + " "
         lik_str += str(node2) + " "
         lik_str += str(this_lik)
 
         lik_file.write(lik_str + "\n")
-        
-    def GetALeaf(this_node,branch_binary_choice):
+
+    def GetALeaf(this_node, branch_binary_choice):
 
         if len(this_node.child_branches) < 1:
             return this_node
@@ -626,4 +546,3 @@ class node:
             for i in the_branch.ends:
                 if i is not this_node:
                     return i.GetALeaf(branch_binary_choice)
-

--- a/clusters/trunk/JointML.py
+++ b/clusters/trunk/JointML.py
@@ -1,22 +1,21 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # AdaptML
 
 import os
 import sys
+import math
 import pdb
 import time
 import random
 
-from numpy.linalg import *
-from numpy.core import *
-from numpy.lib import *
 from numpy import *
+from builtins import sum as _builtin_sum
 
 import multitree
 import ML
 
 start_time = time.time()
-sys.setrecursionlimit(25000)
+sys.setrecursionlimit(50000)
 
 # potential variables:
 tree_fn = None
@@ -25,6 +24,7 @@ migration_fn = None
 mu_fn = None
 thresh_fn = None
 color_map_fn = None
+color_fn = None
 write_dir = None
 cdist = False
 to_truncate = False
@@ -32,7 +32,7 @@ obs_states = None
 
 # load inputs #
 inputs = sys.argv
-for ind in range(1,len(inputs)):
+for ind in range(1, len(inputs)):
     arg_parts = inputs[ind].split('=')
     code = arg_parts[0]
     arg = arg_parts[1]
@@ -50,29 +50,31 @@ for ind in range(1,len(inputs)):
         color_fn = arg
     elif code == 'write':
         write_dir = arg
-    elif code =='thresh':
+    elif code == 'thresh':
         thresh_fn = arg
     elif code == 'cdist':
         cdist = True
-        
+
 # read in data files
 params = {}
 params['cdist'] = cdist
 
 # migration
-migration_f = open(migration_fn,'r')
+migration_f = open(migration_fn, 'r')
 migration_matrix = eval(migration_f.read())
 
-# mu 
-mu_f = open(mu_fn,'r')
+# mu
+mu_f = open(mu_fn, 'r')
 mu = float(mu_f.read().strip())
 mu_f.close()
 
 # colors
-color_f = open(color_fn,'r')
+color_f = open(color_fn, 'r')
 color_hash = {}
 for line in color_f:
     parts = line.strip().split(' ')
+    if len(parts) < 5:
+        continue
     ring_number = parts[0]
     ring_state = parts[1]
     hex_vals = [hex(int(part)) for part in parts[2:]]
@@ -90,9 +92,8 @@ color_f.close()
 # if specified, grab threshold file
 thresh_dict = None
 if thresh_fn is not None:
-    # grab all of the thresholds and toss into a hash
     thresh_dict = {}
-    thresh_f = open(thresh_fn,'r')
+    thresh_f = open(thresh_fn, 'r')
     thresh_lines = thresh_f.readlines()
     for line in thresh_lines:
         line_parts = line.strip().split()
@@ -102,28 +103,27 @@ if thresh_fn is not None:
         thresh_dict[line_parts[0]][line_parts[1]] = thresh
     thresh_f.close()
 
-    # open up files for writing
     bars_fn = write_dir + "/bars.file"
-    bars_f =  open(bars_fn,"w")
+    bars_f = open(bars_fn, "w")
     bar_header = "\t"
-    obs_states = migration_matrix[migration_matrix.keys()[0]].keys()
+    obs_states = list(list(migration_matrix.values())[0].keys())
     for state in obs_states:
         bar_header += state + "\t"
     bars_f.write(bar_header + "\n")
 
     cluster_fn = write_dir + "/cluster.file"
-    cluster_f =  open(cluster_fn,"w")
+    cluster_f = open(cluster_fn, "w")
     prune_fn = write_dir + "/prune.file"
-    prune_f =  open(prune_fn,"w")
+    prune_f = open(prune_fn, "w")
     cdist_fn = write_dir + "/cdist.file"
-    cdist_f =  open(cdist_fn,"w")
+    cdist_f = open(cdist_fn, "w")
 
 lik_fn = write_dir + "/lik.file"
-lik_f =  open(lik_fn,"w")
+lik_f = open(lik_fn, "w")
 
 # build the tree #
-print "Building tree"
-tree_f = open(tree_fn,"r")
+print("Building tree")
+tree_f = open(tree_fn, "r")
 tree_string = tree_f.read().strip()
 tree = multitree.multitree()
 tree.build(tree_string)
@@ -141,24 +141,21 @@ for b in tree.branch_list:
 
 # write the data files
 full_fn = write_dir + "/full.file"
-full_f =  open(full_fn,"w")
+full_f = open(full_fn, "w")
 migration_fn = write_dir + "/habitat.file"
-migration_f =  open(migration_fn,"w")
+migration_f = open(migration_fn, "w")
 
 # write the labels
-habitats = migration_matrix.keys()
+habitats = list(migration_matrix.keys())
 label_line = "LABELS"
-rings = color_hash.keys()
-rings.sort()
+rings = sorted(color_hash.keys())
 for ring in rings:
-    symbols = color_hash[ring].keys()
-    symbols.sort()
+    symbols = sorted(color_hash[ring].keys())
     for symbol in symbols:
         label_line += "," + symbol
 color_line = "COLORS"
 for ring in rings:
-    symbols = color_hash[ring].keys()
-    symbols.sort()
+    symbols = sorted(color_hash[ring].keys())
     for symbol in symbols:
         color_line += "," + color_hash[ring][symbol]
 full_f.write(label_line + "\n")
@@ -182,8 +179,8 @@ tree.color_hash = color_hash
 ML.TreeWipe(tree.a_node)
 
 # learn the likelihoods
-print "Learn habitat assignments"
-ML.LearnLiks(tree,mu,migration_matrix,outgroup)
+print("Learn habitat assignments")
+ML.LearnLiks(tree, mu, migration_matrix, outgroup)
 
 # estimate the states (by making each node trifurcating...)
 root = tree.root
@@ -193,8 +190,8 @@ if kids[0].name in outgroup:
 else:
     true_root = kids[0]
 lik_score = ML.EstimateStates(true_root)
-k = 1 + len(migration_matrix)*(len(migration_matrix.values()[0])-1)
-aic_score = 2*k - 2*lik_score
+k = 1 + len(migration_matrix) * (len(list(migration_matrix.values())[0]) - 1)
+aic_score = 2 * k - 2 * lik_score
 lik_f.write("likelihood: " + str(lik_score) + "\n")
 lik_f.write("aic: " + str(aic_score) + "\n")
 
@@ -218,47 +215,44 @@ if to_truncate:
     min_dist = 0.001
     limit_dist = 0.42
     leaf_dist_fn = write_dir + "/leaves.dist"
-    leaf_dist_f =  open(leaf_dist_fn,"w")
+    leaf_dist_f = open(leaf_dist_fn, "w")
     for leaf in tree.leaf_node_list:
-        this_dist = leaf.DistTo(true_root,None,0)[1]
+        this_dist = leaf.DistTo(true_root, None, 0)[1]
         leaf_dist_f.write(str(this_dist) + "\n")
-        # truncate branches that are too long:
         if this_dist > limit_dist:
-            leaf.TruncateDist(true_root,this_dist,min_dist,limit_dist)
+            leaf.TruncateDist(true_root, this_dist, min_dist, limit_dist)
     leaf_dist_f.close()
 
-    # write out the tree (cheating a little to make the root branches
-    # shorter)
     for branch in tree.root.child_branches:
         branch.length = min_dist
 
 itol_fn = write_dir + "/itol.tree"
-itol_f =  open(itol_fn,"w")
+itol_f = open(itol_fn, "w")
 itol_f.write(true_root.treePrint("") + ";")
 itol_f.close()
 
 # print out the full file
-print "Write out results"
+print("Write out results")
 true_root.FulliTol(files)
 
 if thresh_fn is not None:
 
     strain_fn = write_dir + "/strain.names"
-    strain_f = open(strain_fn,"w")
+    strain_f = open(strain_fn, "w")
 
     # find the divergence points
     divergers = true_root.GetDivergencePoints()
     true_root.divergers = divergers
 
-    true_root.ClusterTest(files,params)
-    true_root.DrawSubclusters(None,cluster_f)
+    true_root.ClusterTest(files, params)
+    true_root.DrawSubclusters(None, cluster_f)
     tree.DrawLeaves(files)
 
     # print lists of constituents in each cluster
-    cluster_roots = filter(lambda a: a.cluster_root,tree.node_dict.values())
+    cluster_roots = [a for a in tree.node_dict.values() if a.cluster_root]
     for cluster_root in cluster_roots:
         strains = cluster_root.leaf_nodes
-        strain_f.write(str(len(strains)) + "\t" + str(cluster_root) +"\n")
+        strain_f.write(str(len(strains)) + "\t" + str(cluster_root) + "\n")
         for strain in strains:
             strain_f.write("\t" + str(strain) + "\n")
         strain_f.write("\n")
@@ -272,7 +266,7 @@ if thresh_fn is not None:
 
     # print pruned topology
     prune_topo_fn = write_dir + "/prune.tree"
-    prune_topo_f =  open(prune_topo_fn,"w")
+    prune_topo_f = open(prune_topo_fn, "w")
     prune_topo_f.write(true_root.treePrint("") + ";")
     prune_topo_f.close()
 
@@ -285,4 +279,3 @@ if thresh_fn is not None:
     cdist_f.close()
     bars_f.close()
     strain_f.close()
-

--- a/clusters/trunk/ML.py
+++ b/clusters/trunk/ML.py
@@ -5,29 +5,30 @@ import copy
 import math
 import pdb
 from numpy import *
-from numpy.matlib import *
 
-def CheckConvergence(tree,old_score,params):
+
+def CheckConvergence(tree, old_score, params):
 
     thresh = float(params[1])
 
     total_prob = 0
     for i in tree.internal_node_list:
         for j in i.ML_probs:
-            total_prob += sum(i.ML_probs[j].values())
+            total_prob += sum(list(i.ML_probs[j].values()))
 
-    total_prob /= len(tree.internal_node_list)*len(tree.species_count)
+    total_prob /= len(tree.internal_node_list) * len(tree.species_count)
 
     if abs(math.log(abs(old_score)) - math.log(abs(total_prob))) < thresh:
         return total_prob, 0
     else:
         return total_prob, 1
-        
+
+
 def EstimateStates(this_node):
 
     kids = this_node.GetKids()
     scores = {}
-    habitats = this_node.ML_probs.values()[0].keys()
+    habitats = list(list(this_node.ML_probs.values())[0].keys())
 
     for habitat in habitats:
         scores[habitat] = 0
@@ -36,7 +37,7 @@ def EstimateStates(this_node):
         for habitat in habitats:
             scores[habitat] += this_node.ML_probs[kid][habitat]
 
-    max_score = -sys.maxint
+    max_score = -sys.maxsize
     max_habitat = None
 
     for habitat in scores:
@@ -44,11 +45,11 @@ def EstimateStates(this_node):
             max_score = scores[habitat]
             max_habitat = habitat
 
-    AssignState(this_node,habitats,max_habitat)
+    AssignState(this_node, habitats, max_habitat)
     return max_score
 
 
-def AssignState(this_node,habitats,max_habitat):
+def AssignState(this_node, habitats, max_habitat):
 
     for habitat in habitats:
         if habitat is max_habitat:
@@ -60,14 +61,15 @@ def AssignState(this_node,habitats,max_habitat):
     this_node.orig_lik = this_node.GetLikelihood()
     this_node.orig_thresh = this_node.GetThresh()
     this_node.likelihood = this_node.GetLikelihood()
-    this_node.threshold = this_node.GetThresh()    
+    this_node.threshold = this_node.GetThresh()
 
     kids = this_node.GetKids()
     for kid in kids:
         kid_habitat = this_node.ML_path[kid][max_habitat]
-        AssignState(kid,habitats,kid_habitat)
+        AssignState(kid, habitats, kid_habitat)
 
-def LearnLiks(tree,mu,migration_matrix,outgroup):
+
+def LearnLiks(tree, mu, migration_matrix, outgroup):
 
     root = tree.root
     kids = root.GetKids()
@@ -77,10 +79,11 @@ def LearnLiks(tree,mu,migration_matrix,outgroup):
         true_root = kids[1]
     else:
         true_root = kids[0]
-        
+
     true_kids = true_root.GetKids()
     for kid in true_kids:
-        MLNode(true_root,kid,mu,migration_matrix)
+        MLNode(true_root, kid, mu, migration_matrix)
+
 
 def TreeWipe(this_node):
 
@@ -93,7 +96,8 @@ def TreeWipe(this_node):
         if len(i.ML_state) > 0:
             TreeWipe(i)
 
-def MLNode(this_node,kid_node,mu,migration_matrix):
+
+def MLNode(this_node, kid_node, mu, migration_matrix):
 
     # no need to recurse if you've already solved this problem
     if kid_node in this_node.ML_probs:
@@ -113,11 +117,11 @@ def MLNode(this_node,kid_node,mu,migration_matrix):
         return
 
     # if not a leaf, need to obtain probabilities of child values:
-    child_nodes = filter(lambda i: i is not this_node, kid_node.other_nodes)
+    child_nodes = [i for i in kid_node.other_nodes if i is not this_node]
     if len(child_nodes) < 1:
-        child_nodes = [None,None]
-    MLNode(kid_node,child_nodes[0],mu,migration_matrix)
-    MLNode(kid_node,child_nodes[1],mu,migration_matrix)    
+        child_nodes = [None, None]
+    MLNode(kid_node, child_nodes[0], mu, migration_matrix)
+    MLNode(kid_node, child_nodes[1], mu, migration_matrix)
 
     t = None
     for branch in this_node.branch_list:
@@ -125,17 +129,17 @@ def MLNode(this_node,kid_node,mu,migration_matrix):
             t = branch.length
 
     hab_num = float(len(migration_matrix))
-    p_xx = 1.0/hab_num + (hab_num-1)/hab_num*math.exp(-hab_num*mu*t)
-    p_xy = 1.0/hab_num*(1-math.exp(-hab_num*mu*t)) 
+    p_xx = 1.0 / hab_num + (hab_num - 1) / hab_num * math.exp(-hab_num * mu * t)
+    p_xy = 1.0 / hab_num * (1 - math.exp(-hab_num * mu * t))
 
-    habitats = migration_matrix.keys()
+    habitats = list(migration_matrix.keys())
 
     # for each of the current nodes possible states
     for this_habitat in habitats:
 
         probs = {}
         for kid_habitat in habitats:
-            
+
             probs[kid_habitat] = 0
 
             if this_habitat is kid_habitat:
@@ -146,7 +150,7 @@ def MLNode(this_node,kid_node,mu,migration_matrix):
             probs[kid_habitat] += math.log(trans_prob)
 
             # handle case at leaves
-            if child_nodes == [None,None]:
+            if child_nodes == [None, None]:
                 prob = kid_node.ML_probs[None][kid_habitat]
                 probs[kid_habitat] += prob
             else:
@@ -154,7 +158,7 @@ def MLNode(this_node,kid_node,mu,migration_matrix):
                 prob2 = kid_node.ML_probs[child_nodes[1]][kid_habitat]
                 probs[kid_habitat] += prob1 + prob2
 
-        high_prob = float(-sys.maxint)
+        high_prob = float(-sys.maxsize)
         max_hab = None
         for a_habitat in probs:
             if probs[a_habitat] > high_prob:
@@ -166,13 +170,12 @@ def MLNode(this_node,kid_node,mu,migration_matrix):
 
     return
 
-def MLNullNode(this_node,kid_node,eigs,MR_matrix):
 
-    # no need to recurse if you've already solved this problem
+def MLNullNode(this_node, kid_node, eigs, MR_matrix):
+
     if kid_node in this_node.ML_null_probs:
         return this_node.ML_null_probs[kid_node]
 
-    # if not ...
     this_node.ML_null_probs[kid_node] = {}
     species_key = eigs["key"]
 
@@ -184,15 +187,15 @@ def MLNullNode(this_node,kid_node,eigs,MR_matrix):
         prob_dict = {}
         for species in spec_count:
             prob_dict[species] = 0
-        
+
         for from_species in spec_count:
             scaling = float(spec_count[from_species])
-            scaling /= sum(spec_count.values())
+            scaling /= sum(list(spec_count.values()))
             for to_species in spec_count:
                 s1 = species_key[from_species]
                 s2 = species_key[to_species]
                 scale_prob = scaling
-                scale_prob *= MR_matrix[s1,s2]
+                scale_prob *= MR_matrix[s1, s2]
                 prob_dict[to_species] += scale_prob
 
         for species in prob_dict:
@@ -201,80 +204,62 @@ def MLNullNode(this_node,kid_node,eigs,MR_matrix):
 
         return this_node.ML_null_probs[kid_node]
 
-    # if not a leaf, need to obtain probabilities of child values:
-    child_nodes = filter(lambda i: i is not this_node, kid_node.other_nodes)
+    child_nodes = [i for i in kid_node.other_nodes if i is not this_node]
     if len(child_nodes) < 1:
-        child_nodes = [None,None]
-    MLNullNode(kid_node,child_nodes[0],eigs,MR_matrix)
-    MLNullNode(kid_node,child_nodes[1],eigs,MR_matrix)    
+        child_nodes = [None, None]
+    MLNullNode(kid_node, child_nodes[0], eigs, MR_matrix)
+    MLNullNode(kid_node, child_nodes[1], eigs, MR_matrix)
 
-    # now, work out transition probability matrix:
     if kid_node in this_node.branch_dict:
         branch_len = this_node.branch_dict[kid_node].length
     elif this_node in kid_node.branch_dict:
         branch_len = kid_node.branch_dict[this_node].length
 
     fst_matrix = eigs["vectors"]
-    sec_matrix = diag(exp(eigs["values"]*branch_len))
+    sec_matrix = diag(exp(eigs["values"] * branch_len))
     trd_matrix = eigs["inverse"]
-    trans_matrix = real(fst_matrix*sec_matrix*trd_matrix)
+    trans_matrix = real(fst_matrix * sec_matrix * trd_matrix)
 
-    # for each of the current nodes possible states
     for this_species in this_node.tree.species_count:
         sum_prob = math.exp(-500)
         for kid_species in this_node.tree.species_count:
 
             prob = 0
-            trans_prob = trans_matrix[species_key[kid_species],species_key[this_species]]
+            trans_prob = trans_matrix[species_key[kid_species], species_key[this_species]]
             if trans_prob < 0:
                 trans_prob = math.exp(-500)
-            
+
             prob += math.log(trans_prob)
 
-            # handle case at leaves
-            if child_nodes == [None,None]:
-                prob +=  kid_node.ML_null_probs[None][kid_species]
+            if child_nodes == [None, None]:
+                prob += kid_node.ML_null_probs[None][kid_species]
             else:
                 prob += kid_node.ML_null_probs[child_nodes[0]][kid_species]
                 prob += kid_node.ML_null_probs[child_nodes[1]][kid_species]
             sum_prob += math.exp(prob)
 
-        #########################################
-        # use pseudocounts to prevent underflow #
-        #########################################
+        # use pseudocounts to prevent underflow
         under_thresh = -150
         pseudocount = this_node.tree.species_count[this_species]
-        sum_prob += pseudocount*exp(under_thresh)
+        sum_prob += pseudocount * exp(under_thresh)
 
         this_node.ML_null_probs[kid_node][this_species] = math.log(sum_prob)
 
-    ############################
-    ### SITE OF BIG PROBLEM? ###
-    ############################
-
-    """
-    # rescale
-    scale_num = sum(exp(array(this_node.ML_null_probs[kid_node].values())))
-    for k in this_node.ML_null_probs[kid_node]:
-        scale_prob = math.exp(this_node.ML_null_probs[kid_node][k])/scale_num
-        this_node.ML_null_probs[kid_node][k] = math.log(scale_prob)
-    """
     return
 
-def GetTransitions(this_branch,parent,eigs,species_key):
+
+def GetTransitions(this_branch, parent, eigs, species_key):
 
     node1 = this_branch.ends[0]
-    node2 = this_branch.ends[1]    
-    
-    # propogate
+    node2 = this_branch.ends[1]
+
     if parent is node1:
         child = node2
     else:
         child = node1
     for i in child.child_branches:
-        GetTransitions(i,child,eigs,species_key)
+        GetTransitions(i, child, eigs, species_key)
 
-    # stop condition
     if node1.isLeaf() or node2.isLeaf():
         return
     if len(node1.ML_probs) < 1:
@@ -282,21 +267,19 @@ def GetTransitions(this_branch,parent,eigs,species_key):
     if len(node2.ML_probs) < 1:
         return
 
-    # compute transition probability matrix
     branch_factor = 10
     branch_len = this_branch.length
     fst_matrix = eigs["vectors"]
-    sec_matrix = diag(exp(eigs["values"]*branch_len*branch_factor))
+    sec_matrix = diag(exp(eigs["values"] * branch_len * branch_factor))
     trd_matrix = eigs["inverse"]
-    trans_matrix = real(fst_matrix*sec_matrix*trd_matrix)
+    trans_matrix = real(fst_matrix * sec_matrix * trd_matrix)
 
-    # now, get the priors
-    keys = node1.ML_probs[node2].keys()
+    keys = list(node1.ML_probs[node2].keys())
     p_child = {}
     p_paren = {}
     for i in keys:
         p_child[i] = 0
-        p_paren[i] = 0        
+        p_paren[i] = 0
     for nodes in child.ML_probs:
         if nodes is not parent:
             for state in keys:
@@ -306,37 +289,20 @@ def GetTransitions(this_branch,parent,eigs,species_key):
             for state in keys:
                 p_paren[state] += parent.ML_probs[nodes][state]
 
-    prob_matrix = matrix(ones((len(species_key),len(species_key))))
+    prob_matrix = matrix(ones((len(species_key), len(species_key))))
     for i in species_key:
         for j in species_key:
             child_ind = species_key[i]
             paren_ind = species_key[j]
             this_prob = 1
-            
-            this_prob *= trans_matrix[paren_ind,child_ind]
+
+            this_prob *= trans_matrix[paren_ind, child_ind]
             this_prob *= math.exp(p_child[i])
             this_prob *= math.exp(p_paren[j])
 
-            prob_matrix[child_ind,paren_ind] = this_prob
-
-    """
-    for i in range(len(species_key)):
-        this_sum = sum(prob_matrix[i,:])
-        for j in range(len(species_key)):
-            prob_matrix[i,j] /= this_sum
-    """
+            prob_matrix[child_ind, paren_ind] = this_prob
 
     keep_state = sum(diag(prob_matrix))
     swap_state = sum(prob_matrix) - keep_state
 
     child.confidence = math.log(keep_state) - math.log(swap_state)
-
-    """
-    foo = child.tree.node_dict["F_FAL492"]
-    bar = child.tree.node_dict["F_FAL45"]
-    if foo in parent.leaf_nodes and foo not in child.leaf_nodes:
-        if bar in child.leaf_nodes:
-            pdb.set_trace()
-    """
-    
-    

--- a/clusters/trunk/branch.py
+++ b/clusters/trunk/branch.py
@@ -1,48 +1,45 @@
-import copy;
+import copy
+
 
 class branch:
 
-    def __init__(self,length):
-        self.ends = []                  # nodes connected to
-        self.length = float(length)	# length (can change during rooting)
-        self.immutable_length = self.length # don't ever change this
-        self.visited = False            # used for traversing the tree
+    def __init__(self, length):
+        self.ends = []                       # nodes connected to
+        self.length = float(length)          # length (can change during rooting)
+        self.immutable_length = self.length  # don't ever change this
+        self.visited = False                 # used for traversing the tree
 
     def __repr__(self):
+        if len(self.ends) == 2:
+            print_string = "(" + self.ends[0].name + ","
+            print_string += self.ends[1].name + "):" + str(self.immutable_length)
+        else:
+            print_string = ":" + str(self.immutable_length)
+        return print_string
 
-	if len(self.ends) == 2:
-	    print_string = "(" + self.ends[0].name + "," 
-	    print_string += self.ends[1].name + "):" + str(self.immutable_length)
-	else:
-	    print_string = ":" + str(self.immutable_length)
-	return print_string
-	
-    def addNode(self,node):
-	self.ends.append(node)
-	node.branch_list.append(self)
+    def addNode(self, node):
+        self.ends.append(node)
+        node.branch_list.append(self)
 
     # recursion for finding all of the branches in an unrooted tree
-    def findBranches(self,all_branches):
-	
-	all_branches.append(self)
-	self.visited = True
+    def findBranches(self, all_branches):
 
-	for node in self.ends:
-	    for brch in node.branch_list:
-		if not brch.visited:
-		    all_branches = brch.findBranches(all_branches)
+        all_branches.append(self)
+        self.visited = True
 
-	return all_branches
+        for node in self.ends:
+            for brch in node.branch_list:
+                if not brch.visited:
+                    all_branches = brch.findBranches(all_branches)
 
-    # recusion to dump all the branches of an unrooted tree into the
-    # provided dictionary
-    def FillBranchDict(this_branch,branch_dict):
+        return all_branches
+
+    def FillBranchDict(this_branch, branch_dict):
 
         for parent_node in this_branch.ends:
             for branch in parent_node.branch_list:
                 if branch is not this_branch:
                     for child_node in branch.ends:
                         if child_node is not parent_node:
-                            print child_node
-                            print child_node.leaves
-            
+                            print(child_node)
+                            print(child_node.leaves)

--- a/clusters/trunk/multitree.py
+++ b/clusters/trunk/multitree.py
@@ -14,22 +14,22 @@ from numpy import *
 import node
 import branch
 
+
 class multitree:
-    
-    # recursive module for building unrooted trees from newick-notated
-    # strings.  
+
+    # recursive module for building unrooted trees from newick-notated strings.
     def __init__(self):
-	self.build_queue = []
+        self.build_queue = []
         self.a_node = None
-	self.a_branch = None
-	self.root = None
-	self.root_branch = None
-	self.num_dups = 0
-	self.num_losses = 0
-	self.num_xfers = 0
-	self.event_queue = []           # keep running list of events
-	self.node_dict = dict()
-	self.mapping_hash = dict()      # store node mappings
+        self.a_branch = None
+        self.root = None
+        self.root_branch = None
+        self.num_dups = 0
+        self.num_losses = 0
+        self.num_xfers = 0
+        self.event_queue = []           # keep running list of events
+        self.node_dict = dict()
+        self.mapping_hash = dict()      # store node mappings
         self.loss_dict = {}             # cache res from countlosses
         self.lca_dict = {}
         self.rec_dict = {}
@@ -40,18 +40,18 @@ class multitree:
         self.branch_list = []
         self.liks = None
         self.migration_matrix = None
-        self.mu = None        
+        self.mu = None
         self.states = None
         self.thresh_dict = {}
         self.base_colors = None
-        
+
     # print the tree (intended for rooted trees)
     def __repr__(self):
-	if self.root == None:
-	    return "not rooted"
-	else:
-	    newickString = ""
-	    return self.root.treePrint(newickString)
+        if self.root is None:
+            return "not rooted"
+        else:
+            newickString = ""
+            return self.root.treePrint(newickString)
 
     # get a list of species
     def GetSpeciesDict(self):
@@ -67,33 +67,28 @@ class multitree:
         return self.species_count
 
     # hijack old build, so as to give opportunity to remove bootstraps
-    # ... 
-    def build(self,newick):
+    def build(self, newick):
 
         # remove any bootstraps from newick
-        p = re.compile('\)[\d\.]+:')
-        newick = p.sub('):',newick)
-        self.RecursiveBuild(newick)  
+        p = re.compile(r'\)[\d\.]+:')
+        newick = p.sub('):', newick)
+        self.RecursiveBuild(newick)
 
-    def RecursiveBuild(self,newick):
+    def RecursiveBuild(self, newick):
 
-	# handle the case when you reach a trifurcating node (so
-	# unrooted), by looking for when you've got a stretch of 2
-	# colons unseparated by a parenthesis
-	colon_match1 = re.findall(':',newick)
-	colon_match2 = re.findall(':[^\)]*:[^\)]*:',newick)
+        colon_match1 = re.findall(':', newick)
+        colon_match2 = re.findall(r':[^\)]*:[^\)]*:', newick)
 
-	# if you reach a root
-	if len(colon_match1) == 1:
+        # if you reach a root
+        if len(colon_match1) == 1:
 
-	    root_node = self.build_queue[0]
-	    
-	    for kid_branches in root_node.branch_list:
-		root_node.child_branches.append(kid_branches)
+            root_node = self.build_queue[0]
 
-            # do rooted stuff
-	    self.root = root_node
-	    self.root.imposeHierarchy()
+            for kid_branches in root_node.branch_list:
+                root_node.child_branches.append(kid_branches)
+
+            self.root = root_node
+            self.root.imposeHierarchy()
             self.labelSubtrees()
             self.Get_Subnodes()
             self.root.Fill_Node_Dict()
@@ -101,23 +96,18 @@ class multitree:
         # handle case of a tree with only 2 nodes:
         elif len(colon_match1) == 2:
 
-	    # find an innermost set of parentheses:
-            regex = re.search('\([^\(\)]*\)',newick).span()
-	    clade = newick[regex[0]+1:regex[1]-1]
+            regex = re.search(r'\([^\(\)]*\)', newick).span()
+            clade = newick[regex[0] + 1:regex[1] - 1]
 
-	    # split up the clade
-	    children = re.split(',',clade)
-	    son = children[0]
-	    daughter = children[1]
+            children = re.split(',', clade)
+            son = children[0]
+            daughter = children[1]
 
-            # build node1
             node1 = self.BuildNode(son)
             node2 = self.BuildNode(daughter)
 
-	    # unite the two nodes
-	    center_node = node1.unite(node2)
-            
-            # create a fake node:
+            center_node = node1.unite(node2)
+
             dummy_node = self.BuildNode("dummy_node:0.1")
             dummy_node.branch_list = []
             self.leaf_count -= 1
@@ -127,49 +117,35 @@ class multitree:
             self.a_node = dummy_node
             center_node.UnrootedLeaving()
 
-	# handle the trifurcating node of an unrooted tree
-	elif len(colon_match1) == 3 and len(colon_match2) > 0:
+        # handle the trifurcating node of an unrooted tree
+        elif len(colon_match1) == 3 and len(colon_match2) > 0:
 
-            # note that this updated block can handle trees with leaf
-            # count >= 3
+            regex = re.search(r'\([^,]*,', newick).span()
+            first_leaf = newick[regex[0] + 1:regex[1] - 1]
 
-            # pull out the first node
-            regex = re.search('\([^,]*,',newick).span()
-            first_leaf = newick[regex[0]+1:regex[1]-1]
-
-            ####newick = re.sub(first_leaf + ',','',newick)
-            newick = newick.replace(first_leaf + ',','')
+            newick = newick.replace(first_leaf + ',', '')
 
             first_node = self.BuildNode(first_leaf)
 
-            # first_node.branch_list = []
-            # don't need to worry about clearing, since we'll be
-            # adding branches anyway later down in this block.
             self.build_queue.append(first_node)
 
-	    # join the last 2 nodes:
-            regex = re.search('\(.*,[^\)]*\);',newick).span()
-            clade = newick[regex[0]+1:regex[1]-2]
+            regex = re.search(r'\(.*,[^\)]*\);', newick).span()
+            clade = newick[regex[0] + 1:regex[1] - 2]
 
-            # split up the clade
-            children = re.split(',',clade)
+            children = re.split(',', clade)
             son = children[0]
             daughter = children[1]
 
-            # build two nodes and join
             node1 = self.BuildNode(son)
             node2 = self.BuildNode(daughter)
             center_node = node1.unite(node2)
 
-            # finally, join this new node with the remaining node:
             last_node = self.build_queue[0]
-            regex = re.search(':[^,]*,',newick).span()
+            regex = re.search(r':[^,]*,', newick).span()
             last_node.myBranch.addNode(center_node)
 
             self.a_branch = last_node.myBranch
 
-            # do some unrooted stuff, making sure you don't begin on a
-            # leaf. 
             if len(self.a_branch.ends[0].branch_list) == 3:
                 self.a_node = self.a_branch.ends[0]
                 self.a_branch.ends[0].UnrootedLeaving()
@@ -177,38 +153,31 @@ class multitree:
                 self.a_node = self.a_branch.ends[1]
                 self.a_branch.ends[1].UnrootedLeaving()
 
-	else:
+        else:
 
-	    # find an innermost set of parentheses:
-	    regex = re.search('\([^\(\)]*\):',newick).span()
-	    clade = newick[regex[0]+1:regex[1]-2]
+            regex = re.search(r'\([^\(\)]*\):', newick).span()
+            clade = newick[regex[0] + 1:regex[1] - 2]
 
-	    # split up the clade
-	    children = re.split(',',clade)
-	    son = children[0]
-	    daughter = children[1]
+            children = re.split(',', clade)
+            son = children[0]
+            daughter = children[1]
 
-            # build nodes and unite
             node1 = self.BuildNode(son)
             node2 = self.BuildNode(daughter)
-	    center_node = node1.unite(node2)
+            center_node = node1.unite(node2)
 
-	    # replace the matched string with the new node:
-	    new_newick = newick[0:regex[0]]
-	    new_newick += center_node.name
-	    new_newick += newick[regex[1]-1:]
+            new_newick = newick[0:regex[0]]
+            new_newick += center_node.name
+            new_newick += newick[regex[1] - 1:]
 
-	    # add the new node to the queue of extant nodes
-	    self.build_queue.append(center_node)
+            self.build_queue.append(center_node)
 
-	    # recurse
-	    self.RecursiveBuild(new_newick)
+            self.RecursiveBuild(new_newick)
 
     # create a new node:
-    def BuildNode(this_tree,node_string):
-        splitSon = re.split(':',node_string)
+    def BuildNode(this_tree, node_string):
+        splitSon = re.split(':', node_string)
 
-        # see if anyone in the queue has the same name
         node1match = False
         for i in range(len(this_tree.build_queue)):
             if this_tree.build_queue[i].name == splitSon[0]:
@@ -217,8 +186,8 @@ class multitree:
                 node1match = True
                 break
         if node1match is not True:
-            node1 = node.node(splitSon[0],this_tree)
-            this_tree.leaf_count += 1   # another leaf added to tree 
+            node1 = node.node(splitSon[0], this_tree)
+            this_tree.leaf_count += 1
 
         node1.addBranch(splitSon[1])
 
@@ -226,62 +195,55 @@ class multitree:
 
     # label the subtrees
     def labelSubtrees(self):
-
-	if self.root == None:
-	    print "you're trying to label an unrooted tree"
-	else:
-	    self.root.subtreeLabel()
-
+        if self.root is None:
+            print("you're trying to label an unrooted tree")
+        else:
+            self.root.subtreeLabel()
 
     # get all subnodes (useful for finding LCAs)
     def Get_Subnodes(self):
-	self.root.Find_Subnodes()
+        self.root.Find_Subnodes()
 
+    def rootify(self, center_branch):
 
-    def rootify(self,center_branch):
+        self.root_branch = center_branch
 
-	# remember the old branch:
-	self.root_branch = center_branch
+        center_name = center_branch.ends[0].name
+        center_name += "-" + center_branch.ends[1].name
+        center_node = node.node(center_name, self)
+        self.root = center_node
 
-	# create a new node
-	center_name = center_branch.ends[0].name
-	center_name += "-" + center_branch.ends[1].name
-	center_node = node.node(center_name,self)
-	self.root = center_node
-	
-	# give it children branches
-	child1 = branch.branch(center_branch.length/2)
-	child1.addNode(center_node)
-	child1.addNode(center_branch.ends[0])
-	child2 = branch.branch(center_branch.length/2)
-	child2.addNode(center_node)
-	child2.addNode(center_branch.ends[1])
-	center_node.child_branches.append(child1)
-	center_node.child_branches.append(child2)
+        child1 = branch.branch(center_branch.length / 2)
+        child1.addNode(center_node)
+        child1.addNode(center_branch.ends[0])
+        child2 = branch.branch(center_branch.length / 2)
+        child2.addNode(center_node)
+        child2.addNode(center_branch.ends[1])
+        center_node.child_branches.append(child1)
+        center_node.child_branches.append(child2)
 
-	# erase the original branch from the child nodes branch_list
-	for kids in center_branch.ends:
-	    kids.branch_list.remove(center_branch)
+        # erase the original branch from the child nodes branch_list
+        for kids in center_branch.ends:
+            kids.branch_list.remove(center_branch)
 
-	# impose a hierarchy from the root
-	center_node.imposeHierarchy()
+        # impose a hierarchy from the root
+        center_node.imposeHierarchy()
         self.labelSubtrees()
         self.Get_Subnodes()
         self.root.Fill_Node_Dict()
 
-    def MatchNodes(this_tree,that_tree):
+    def MatchNodes(this_tree, that_tree):
 
         match_dict = {}
 
-        this_node_list = this_tree.node_dict.values()
-        that_node_list = that_tree.node_dict.values()
+        this_node_list = list(this_tree.node_dict.values())
+        that_node_list = list(that_tree.node_dict.values())
 
         for this_node in this_node_list:
             for that_node in that_node_list:
 
-                # do these two nodes have the same number of leaves?
-                these_leaves = map(lambda i:i.name,this_node.leaf_nodes)
-                those_leaves = map(lambda i:i.name,that_node.leaf_nodes)
+                these_leaves = [i.name for i in this_node.leaf_nodes]
+                those_leaves = [i.name for i in that_node.leaf_nodes]
 
                 if len(these_leaves) != len(those_leaves):
                     continue
@@ -295,14 +257,13 @@ class multitree:
                 if leaf_match:
                     match_dict[this_node] = that_node
                     that_node_list.remove(that_node)
-                
+
         return match_dict
-        
-    def DrawLeaves(this_tree,files):
+
+    def DrawLeaves(this_tree, files):
 
         cluster_file = files['cluster']
 
         for leaf in this_tree.leaf_node_list:
             this_str = leaf.PrintiTolLeaf()
             cluster_file.write(this_str + "\n")
-

--- a/clusters/trunk/node.py
+++ b/clusters/trunk/node.py
@@ -2,76 +2,69 @@ import random
 import re
 import copy
 import sys
+import math
 import pdb
 
 from numpy import *
-from sets import Set
 
 import multitree
 import branch
 
+
 class node:
 
-    def __init__(self,name,arbre):
+    def __init__(self, name, arbre):
 
-        self.name_backup = name # argh, i need to refactor
+        self.name_backup = name
         self.name = name
 
         # assign species names by stripping '.X' or '_X'
         match_str = re.compile(r'[\._]\w*-')
-        name = match_str.sub('-',name,0)
-        # catch trailers
+        name = match_str.sub('-', name, 0)
         match_str = re.compile(r'[\._]\w*')
-        species = match_str.sub('',name,0)
+        species = match_str.sub('', name, 0)
 
         self.species = species
         self.perturb_species = species
-	self.range = []
-	self.range.append(self.species)
+        self.range = []
+        self.range.append(self.species)
         self.tree = arbre
-	self.lca_scores = dict()        # keep track of lca scores
-	self.event_str = dict()         # keep track of events for each lca
-	    
-	# clear all of the other variables
-        self.myBranch = None            # used to construct unrooted trees
-	self.branch_list = []           # used to construct unrooted trees
-	self.child_branches = []        # list of branches to kids
-	self.parent_branch = []         # should have length 1
-        
-	self.subnodes = dict()          # all nodes below this
-	self.leaves = None              # leaves below this
+        self.lca_scores = dict()
+        self.event_str = dict()
+
+        self.myBranch = None
+        self.branch_list = []
+        self.child_branches = []
+        self.parent_branch = []
+
+        self.subnodes = dict()
+        self.leaves = None
         self.leaf_nodes = []
-        
-        # attach to each node a serial number, to tell nodes apart
-	#self.serial = random.randint(-sys.maxint,sys.maxint)
+
         self.serial = hash(self.name)
         self.newick_string = ""
         self.counts_dict = {}
         self.ancestors = []
 
-	self.visited = False            # useful for rooting trees
-        self.dup_count = 0              # number of duplications at this node
+        self.visited = False
+        self.dup_count = 0
 
-        # things for GetNodeLinkDict
         self.link_dict_visited = False
 
-        # things necessary for UnrootedLeaving
         self.leaf_dict = {}
-        self.name_dict = {}        
+        self.name_dict = {}
         self.branch_dict = {}
         self.unrooted_leaving_visited = False
         self.other_nodes = []
 
-        # stuff for global reconcile:
-        self.lca_lookups = {}  # store here 3 lookup tables, 1 for
-                               # each of the possible parents of this node
+        self.lca_lookups = {}
 
         # ML things
         self.ML_probs = {}
         self.ML_path = {}
-        self.ML_null_probs = {}        
+        self.ML_null_probs = {}
         self.ML_state = {}
-        self.old_state = array([0,0,0])
+        self.old_state = array([0, 0, 0])
         self.sum_lik = 0
 
         # cluster things
@@ -92,48 +85,35 @@ class node:
         self.div_tested = False
 
     def __repr__(self):
-	#if self.myBranch == None:
-	#    return self.name
-	#else:	
-	#    return self.name + ":" + str(self.myBranch.length)
-        return self.name 
-    
-    def __eq__(self,other):
-	if self is None or other is None:
-	    return False
-	elif self.serial == other.serial:
-	    return True
-	else:
-	    return False
+        return self.name
 
-    def __ne__(self,other):
+    def __eq__(self, other):
+        if self is None or other is None:
+            return False
+        elif self.serial == other.serial:
+            return True
+        else:
+            return False
 
-	if self is None or other is None:
-	    return True
-	elif self.serial == other.serial:
-	    return False
-	else:
-	    return True
+    def __ne__(self, other):
+        if self is None or other is None:
+            return True
+        elif self.serial == other.serial:
+            return False
+        else:
+            return True
 
-    def __gt__(self,other):
-	if self.name > other.name:
-	    return True
-	else:
-	    return False
+    def __gt__(self, other):
+        return self.name > other.name
 
-    def __lt__(self,other):
-	if self.name < other.name:
-	    return True
-	else:
-	    return False
+    def __lt__(self, other):
+        return self.name < other.name
+
     def __hash__(self):
         return self.serial
 
     def isLeaf(self):
-	if len(self.child_branches) < 1:
-	    return True
-	else:
-	    return False
+        return len(self.child_branches) < 1
 
     def GetKids(self):
         kids = []
@@ -142,28 +122,25 @@ class node:
                 if j is not self:
                     kids.append(j)
         return kids
-	
+
     def PrintStates(this_node):
 
         if len(this_node.ML_state) > 0:
             if max(this_node.ML_state.values()) > 0:
 
-                print "node:",
-                node_name = this_node.treePrint("",0)
-                if node_name[0] is not "(":
-                    print "(" + node_name + ")"
+                print("node:", end=' ')
+                node_name = this_node.treePrint("", 0)
+                if node_name[0] != "(":
+                    print("(" + node_name + ")")
                 else:
-                    print node_name
-                print "prob:",
+                    print(node_name)
+                print("prob:", end=' ')
                 for state in this_node.ML_state:
-                    print state + ":", round(this_node.ML_state[state],3), 
-                print
+                    print(state + ":", round(this_node.ML_state[state], 3), end=' ')
+                print()
 
-                print "lik:", this_node.sum_lik
-                
-                #for state in this_node.ML_probs:
-                #    print state + ":", round(this_node.ML_probs[state],3), 
-                print
+                print("lik:", this_node.sum_lik)
+                print()
 
         for branch in this_node.child_branches:
             for kid_node in branch.ends:
@@ -176,240 +153,201 @@ class node:
 
         if this_node.tree.root is this_node:
             return parent
-        
+
         if len(this_node.parent_branch) > 0:
             for i in this_node.parent_branch[0].ends:
                 if i is not this_node:
                     parent = i
         return parent
-	
-    # recursively print out nodes
-    def BootPrint(self,newickString,verbose=1):
 
-	count = 0
+    def BootPrint(self, newickString, verbose=1):
 
-	for kid_branches in self.child_branches:
-	    for kid_nodes in kid_branches.ends:
-		if kid_nodes is not self:
-		    if count == 0:
-			newickString += "("
-			newickString = kid_nodes.BootPrint(newickString,verbose)
-		    else:
-			newickString += ","
-			newickString = kid_nodes.BootPrint(newickString,verbose)
-			newickString += ")"
-		    count += 1
+        count = 0
 
-        # add ability to print state probabilities
+        for kid_branches in self.child_branches:
+            for kid_nodes in kid_branches.ends:
+                if kid_nodes is not self:
+                    if count == 0:
+                        newickString += "("
+                        newickString = kid_nodes.BootPrint(newickString, verbose)
+                    else:
+                        newickString += ","
+                        newickString = kid_nodes.BootPrint(newickString, verbose)
+                        newickString += ")"
+                    count += 1
+
         boot_str = ""
         if len(self.child_branches) > 1:
             if len(self.ML_state) > 0:
                 for i in self.ML_state:
                     boot_str += "|" + i + "|"
-                    boot_str += "-" + str(round(self.ML_state[i],3))
+                    boot_str += "-" + str(round(self.ML_state[i], 3))
 
         newickString += boot_str
 
         addString = ""
         if verbose:
             if len(self.parent_branch) > 0 and len(self.child_branches) == 0:
-                addString = self.name + ":" + str(self.parent_branch[0].length) 
-            elif len(self.parent_branch) > 0: 
+                addString = self.name + ":" + str(self.parent_branch[0].length)
+            elif len(self.parent_branch) > 0:
                 addString = ":" + str(self.parent_branch[0].length)
         else:
             if len(self.parent_branch) > 0 and len(self.child_branches) == 0:
-                addString = self.species + ":" + str(self.parent_branch[0].length) 
-            elif len(self.parent_branch) > 0: 
+                addString = self.species + ":" + str(self.parent_branch[0].length)
+            elif len(self.parent_branch) > 0:
                 addString = ":" + str(self.parent_branch[0].length)
 
-	return newickString + addString
-                
+        return newickString + addString
 
-    def addBranch(self,length):
+    def addBranch(self, length):
+        self.myBranch = branch.branch(length)
+        self.myBranch.addNode(self)
 
-	self.myBranch = branch.branch(length)
-	self.myBranch.addNode(self)
+    def treePrint(self, newickString, verbose=1):
 
-    # recursively print out nodes
-    def treePrint(self,newickString,verbose=1):
+        count = 0
 
-	count = 0
-
-	for kid_branches in self.child_branches:
-	    for kid_nodes in kid_branches.ends:
-		if kid_nodes is not self:
-		    if count == 0:
-			newickString += "("
-			newickString = kid_nodes.treePrint(newickString,verbose)
-		    else:
-			newickString += ","
-			newickString = kid_nodes.treePrint(newickString,verbose)
-			newickString += ")"
-		    count += 1
+        for kid_branches in self.child_branches:
+            for kid_nodes in kid_branches.ends:
+                if kid_nodes is not self:
+                    if count == 0:
+                        newickString += "("
+                        newickString = kid_nodes.treePrint(newickString, verbose)
+                    else:
+                        newickString += ","
+                        newickString = kid_nodes.treePrint(newickString, verbose)
+                        newickString += ")"
+                    count += 1
 
         addString = ""
 
         if verbose:
             if len(self.parent_branch) > 0 and len(self.child_branches) == 0:
-                addString = self.name + ":" + str(self.parent_branch[0].length) 
-            elif len(self.parent_branch) > 0: 
+                addString = self.name + ":" + str(self.parent_branch[0].length)
+            elif len(self.parent_branch) > 0:
                 addString = ":" + str(self.parent_branch[0].length)
         else:
             if len(self.parent_branch) > 0 and len(self.child_branches) == 0:
-                addString = self.name 
-	return newickString + addString
+                addString = self.name
+        return newickString + addString
 
-    # join two nodes in a central node
-    def unite(self,node2):
+    def unite(self, node2):
 
-	# create a new node
-	new_node_name = self.name + "-" + node2.name
-	center_node = node(new_node_name,self.tree)
-	self.myBranch.addNode(center_node)
-	node2.myBranch.addNode(center_node)
-	return center_node
+        new_node_name = self.name + "-" + node2.name
+        center_node = node(new_node_name, self.tree)
+        self.myBranch.addNode(center_node)
+        node2.myBranch.addNode(center_node)
+        return center_node
 
-    # recursively impose a hierarchy
     def imposeHierarchy(self):
 
-	# find all the child nodes that have yet to be visited and
-	# assign their children
-	for kid_branch in self.child_branches:
-	    for node in kid_branch.ends:
-		if not node.visited and node is not self:
-		    node.visited = True
-		    node.parent_branch.append(kid_branch)
-		    for child_branch in node.branch_list:
-			if child_branch is not kid_branch:
-			    node.child_branches.append(child_branch)
-			    node.imposeHierarchy()
+        for kid_branch in self.child_branches:
+            for node in kid_branch.ends:
+                if not node.visited and node is not self:
+                    node.visited = True
+                    node.parent_branch.append(kid_branch)
+                    for child_branch in node.branch_list:
+                        if child_branch is not kid_branch:
+                            node.child_branches.append(child_branch)
+                            node.imposeHierarchy()
 
-    # recursively label the roots of subtrees w/ the leaves contained
-    # below
     def subtreeLabel(self):
 
-	leaf_vec = []
-	
-	if self.leaves is not None:
-	    return self.leaves
+        leaf_vec = []
 
-	# recurse
+        if self.leaves is not None:
+            return self.leaves
+
         kids = self.GetKids()
         for kid in kids:
             child_leaves = kid.subtreeLabel()
             leaf_vec.extend(child_leaves)
 
-	# once you hit a leaf
-	if len(self.child_branches) == 0:
-	    leaf_vec.append(self.species)
+        if len(self.child_branches) == 0:
+            leaf_vec.append(self.species)
             self.leaf_nodes.append(self)
             self.prune_leaves.append(self)
         else:
             for kid in kids:
                 self.leaf_nodes.extend(kid.leaf_nodes)
                 self.prune_leaves.extend(kid.prune_leaves)
-                
-	# non-duplicates:
-	leaf_vec = dict(map(lambda i: (i,1),leaf_vec))
-	self.leaves = leaf_vec
-	return leaf_vec.keys()
 
-    # figure out which species tree node a gene tree node maps to
-    def subtreeMap(self,species_node):
-	
-	# do the children of the current species node possess the
-	# relevant genes?  if so, follow that child.  if not, return
-	# the current node
+        leaf_vec = dict(map(lambda i: (i, 1), leaf_vec))
+        self.leaves = leaf_vec
+        return list(leaf_vec.keys())
 
-	foundSet = 0
-	for kid_branches in species_node.child_branches:
-	    for kid_nodes in kid_branches.ends:
-		if kid_nodes is not species_node:
+    def subtreeMap(self, species_node):
 
-		    s_leaves = kid_nodes.leaves
-		    g_leaves = self.leaves
+        foundSet = 0
+        for kid_branches in species_node.child_branches:
+            for kid_nodes in kid_branches.ends:
+                if kid_nodes is not species_node:
 
-		    # count how many elements of the gene set of
-		    # leaves are not in the species set of leaves
+                    s_leaves = kid_nodes.leaves
+                    g_leaves = self.leaves
 
-		    n = 0
-		    for i in g_leaves.keys():
-			if not i in s_leaves:
-			    n += 1
-			    break
-		    
-		    # if you can see somewhere to descend, follow it
-		    if n == 0:
-			return self.subtreeMap(kid_nodes)
+                    n = 0
+                    for i in g_leaves.keys():
+                        if i not in s_leaves:
+                            n += 1
+                            break
 
-	# once you've run out of places to descend, just return
-	# wherever you've ended up:
-	return species_node
+                    if n == 0:
+                        return self.subtreeMap(kid_nodes)
 
-    # recursively store at each node a hash of all nodes below
+        return species_node
+
     def Find_Subnodes(self):
 
-	for kid_branches in self.child_branches:
-	    for kid_nodes in kid_branches.ends:
-		if kid_nodes is not self:
-		    new_dict = kid_nodes.Find_Subnodes()
-		    for k in new_dict.keys():
-			if not k in self.subnodes:
-			    self.subnodes[k] = 1
-		    # self.subnodes.extend(kid_nodes.Find_Subnodes())
+        for kid_branches in self.child_branches:
+            for kid_nodes in kid_branches.ends:
+                if kid_nodes is not self:
+                    new_dict = kid_nodes.Find_Subnodes()
+                    for k in new_dict.keys():
+                        if k not in self.subnodes:
+                            self.subnodes[k] = 1
 
-	# self.subnodes.append(self)
-	self.subnodes[self.species] = 1
-	return self.subnodes
+        self.subnodes[self.species] = 1
+        return self.subnodes
 
-    # find the last common ancestor of two nodes.  will descend from
-    # the subroot (self) looking to see which children possess both
-    # nodes.  if neither children possess both nodes, return current
-    # node
-
-    def Find_LCA(self,node1,node2):
+    def Find_LCA(self, node1, node2):
 
         for kid_branches in self.child_branches:
             for kid_nodes in kid_branches.ends:
                 if kid_nodes is not self:
                     if node1.species in kid_nodes.subnodes:
                         if node2.species in kid_nodes.subnodes:
-                            return kid_nodes.Find_LCA(node1,node2)
+                            return kid_nodes.Find_LCA(node1, node2)
         return self
 
-    # get list of all vertices in a tree
     def Fill_Node_Dict(vertex):
-	
-	# vertex.tree.node_dict[vertex.name] = vertex
+
         vertex.tree.node_dict[vertex.name] = vertex
 
-	for kid_branches in vertex.child_branches:
-	    for kid_nodes in kid_branches.ends:
-		if kid_nodes is not vertex:
-		    kid_nodes.Fill_Node_Dict()
+        for kid_branches in vertex.child_branches:
+            for kid_nodes in kid_branches.ends:
+                if kid_nodes is not vertex:
+                    kid_nodes.Fill_Node_Dict()
 
-    # initialize hash tables for lca scores for each node
-    def Init_LCA_Scores(vertex,node_dict):
+    def Init_LCA_Scores(vertex, node_dict):
 
-	for tnode in node_dict:
-	    vertex.lca_scores[tnode.name] = node.maxInt
+        for tnode in node_dict:
+            vertex.lca_scores[tnode.name] = node.maxInt
 
-	for kid_branches in vertex.child_branches:
-	    for kid_nodes in kid_branches.ends:
-		if kid_nodes is not vertex:
-		    kid_nodes.Init_LCA_Scores(node_dict)
+        for kid_branches in vertex.child_branches:
+            for kid_nodes in kid_branches.ends:
+                if kid_nodes is not vertex:
+                    kid_nodes.Init_LCA_Scores(node_dict)
 
-    # determine if one node is descended from the other ...
-    def Are_Related(node1,node2):
+    def Are_Related(node1, node2):
 
-	verdict = False
-	for e in node1.leaves.keys():
-	    if e in node2.leaves:
-		verdict = True
+        verdict = False
+        for e in node1.leaves.keys():
+            if e in node2.leaves:
+                verdict = True
 
-	return verdict
+        return verdict
 
-    # method to list all the leaves of this node, keyed by the parent
     def UnrootedLeaving(this_node):
 
         for branches in this_node.branch_list:
@@ -419,27 +357,23 @@ class node:
         this_node.tree.internal_node_list.append(this_node)
         other_nodes = this_node.GetOtherNodes()
 
-        # get leaves in each direction
         for parent_node in other_nodes:
 
-            child_nodes = list(Set(other_nodes).difference(Set([parent_node])))
-            this_node.GetChildLeaves(parent_node,child_nodes)
+            child_nodes = list(set(other_nodes).difference({parent_node}))
+            this_node.GetChildLeaves(parent_node, child_nodes)
 
-        # when done, move on to neighboring nodes:
         for node in other_nodes:
 
-            if len(node.leaf_dict) is not len(node.branch_list):
+            if len(node.leaf_dict) != len(node.branch_list):
                 node.UnrootedLeaving()
-                
-    def GetLeaves(this_node,parent_node):
 
-        # if the leaf dict has already been defined:
+    def GetLeaves(this_node, parent_node):
+
         if parent_node in this_node.leaf_dict:
             return this_node.leaf_dict[parent_node], this_node.name_dict[parent_node]
 
-        # if is a leaf
         if len(this_node.branch_list) < 2:
-            
+
             this_node.tree.leaf_node_list.append(this_node)
 
             if this_node.species in this_node.tree.species_count:
@@ -448,16 +382,16 @@ class node:
                 this_node.tree.species_count[this_node.species] = 1
 
             this_node.leaf_dict[parent_node] = [this_node.species]
-            this_node.name_dict[parent_node] = [this_node.name]          
+            this_node.name_dict[parent_node] = [this_node.name]
             return this_node.leaf_dict[parent_node], this_node.name_dict[parent_node]
 
         other_nodes = this_node.GetOtherNodes()
-        child_nodes = list(Set(other_nodes).difference(Set([parent_node])))
-        this_node.GetChildLeaves(parent_node,child_nodes)
-            
+        child_nodes = list(set(other_nodes).difference({parent_node}))
+        this_node.GetChildLeaves(parent_node, child_nodes)
+
         return this_node.leaf_dict[parent_node], this_node.name_dict[parent_node]
 
-    def GetChildLeaves(this_node,parent_node,other_nodes):
+    def GetChildLeaves(this_node, parent_node, other_nodes):
 
         merge_list = []
         name_list = []
@@ -468,7 +402,7 @@ class node:
                     continue
 
             kid_leaves, kid_names = kid_node.GetLeaves(this_node)
-            
+
             if type(kid_leaves[0]) is not type(''):
                 merge_list.extend(kid_leaves[0])
                 name_list.extend(kid_names[0])
@@ -476,7 +410,6 @@ class node:
                 merge_list.extend(kid_leaves)
                 name_list.extend(kid_names)
 
-            # this is a total hack
             this_node.leaf_dict[parent_node] = []
             this_node.name_dict[parent_node] = []
 
@@ -485,7 +418,7 @@ class node:
         this_node.leaf_dict[parent_node].extend(merge_list)
         this_node.name_dict[parent_node].extend(name_list)
 
-    def GetNodeLinkDict(this_node,node_link_dict):
+    def GetNodeLinkDict(this_node, node_link_dict):
 
         this_node.link_dict_visited = True
         leaf_dict = this_node.leaf_dict
@@ -496,27 +429,23 @@ class node:
             if type(subleaves[0]) == type([]):
                 subleaves = subleaves[0]
             sub_str = repr(subleaves)
-            
-            if sub_str in node_link_dict:
-                node_link_dict[sub_str].append((this_node,key))
-            else:
-                node_link_dict[sub_str] = [(this_node,key)]
-            # node_link_dict[sub_str] = (this_node,key)
 
-        # after that's been done, decide where to recurse
+            if sub_str in node_link_dict:
+                node_link_dict[sub_str].append((this_node, key))
+            else:
+                node_link_dict[sub_str] = [(this_node, key)]
+
         for relative in leaf_dict:
 
-            relative_keys = relative.leaf_dict.keys()
+            relative_keys = list(relative.leaf_dict.keys())
             subleaves = relative.leaf_dict[relative_keys[0]]
             subleaves.sort()
 
             if not relative.link_dict_visited:
                 relative.GetNodeLinkDict(node_link_dict)
 
-    # return a list of all bordering nodes
     def GetOtherNodes(this_node):
 
-        # fill out the leaf dictionary
         other_nodes = []
         for branch in this_node.branch_list:
             for node in branch.ends:
@@ -527,36 +456,31 @@ class node:
 
         return other_nodes
 
-    # get the distance between two nodes:
-    # call as follows:
-    # found, dist = node1.DistTo(node2)
-    def DistTo(this_node,that_node,this_branch=None,dist=0):
+    def DistTo(this_node, that_node, this_branch=None, dist=0):
 
-        # what to do at the end
         if this_node is that_node:
             return True, dist
 
-        # if not ...
         was_found = False
         found_dist = dist
         for i in this_node.branch_list:
             if i is not this_branch:
                 for j in i.ends:
                     if j is not this_node:
-                        found, new_dist = j.DistTo(that_node,i,dist+i.immutable_length)
+                        found, new_dist = j.DistTo(that_node, i, dist + i.immutable_length)
                         if found is True:
                             was_found = found
                             found_dist = new_dist
 
         return was_found, found_dist
-        
+
     def NodeWipe(this_node):
 
         for kid_branches in this_node.child_branches:
             for kid_nodes in kid_branches.ends:
                 if kid_nodes is not this_node:
                     kid_nodes.NodeWipe()
-                        
+
         this_node.child_branches = []
         this_node.parent_branch = []
         this_node.subnodes = {}
@@ -564,7 +488,7 @@ class node:
         this_node.ML_state = {}
         this_node.ML_probs = {}
 
-    def LearnMR(this_node,MR_matrix,species_key):
+    def LearnMR(this_node, MR_matrix, species_key):
 
         if len(this_node.branches) < 1:
             pdb.set_trace()
@@ -572,9 +496,9 @@ class node:
         for i in this_node.child_branches:
             for j in i.ends:
                 if j is not this_node:
-                    j.LearnMR(MR_matrix,species_key)
-        
-    def GetALeaf(this_node,branch_binary_choice):
+                    j.LearnMR(MR_matrix, species_key)
+
+    def GetALeaf(this_node, branch_binary_choice):
 
         if len(this_node.child_branches) < 1:
             return this_node
@@ -585,14 +509,12 @@ class node:
                 if i is not this_node:
                     return i.GetALeaf(branch_binary_choice)
 
-    def TruncateDist(this_node,root,this_dist,min_dist,limit_dist):
+    def TruncateDist(this_node, root, this_dist, min_dist, limit_dist):
 
         parent_dist = this_node.parent_branch[0].length
 
-        # how much distance is necessary?
         nec_dist = this_dist - limit_dist
 
-        # if all you need to do is shorten this branch
         if nec_dist < parent_dist:
             new_dist = parent_dist - nec_dist
             this_node.parent_branch[0].length = new_dist
@@ -601,15 +523,15 @@ class node:
             this_dist -= parent_dist + min_dist
             this_node.parent_branch[0].length = new_dist
             parent = this_node.GetParent()
-            parent.TruncateDist(root,this_dist,min_dist,limit_dist)
+            parent.TruncateDist(root, this_dist, min_dist, limit_dist)
         return
-        
-    def RemoveLeaves(this_node,cluster_node):
+
+    def RemoveLeaves(this_node, cluster_node):
 
         for leaf in cluster_node.leaf_nodes:
             if leaf not in this_node.leaf_nodes:
                 pdb.set_trace()
-            
+
             this_node.leaf_nodes.remove(leaf)
         parent = this_node.GetParent()
         if parent is not None:
@@ -640,7 +562,6 @@ class node:
         leaf1 = this_node.GetALeaf(0).name
         leaf2 = this_node.GetALeaf(1).name
 
-        # you're at a leaf
         if leaf1 == leaf2:
             return 0
 
@@ -649,57 +570,48 @@ class node:
         else:
             return thresh_dict[leaf1][leaf2]
 
-    def SubtractLikelihood(this_node,lik_diff,thresh_diff):
+    def SubtractLikelihood(this_node, lik_diff, thresh_diff):
 
         if this_node is this_node.tree.root:
             return
 
-        # adjust likelihoods and thresholds
         this_node.likelihood -= lik_diff
         this_node.threshold -= thresh_diff
         parent_node = this_node.GetParent()
         if parent_node is not this_node.tree.root:
-            parent_node.SubtractLikelihood(lik_diff,thresh_diff)
+            parent_node.SubtractLikelihood(lik_diff, thresh_diff)
 
-    # remove a leaf from a tree
     def RemoveLeaf(this_node):
 
         tree = this_node.tree
 
         if not this_node.isLeaf():
-            print "this node isn't a leaf."
+            print("this node isn't a leaf.")
             sys.exit(1)
 
         parent_node = this_node.GetParent()
         kids = parent_node.GetKids()
-        sib = filter(lambda i: i is not this_node,kids)[0]
+        sib = [i for i in kids if i is not this_node][0]
 
-        # what to do if parent is the root
         if tree.root is parent_node:
             tree.root = sib
             return
 
-        # if not tied to root, slightly more complex ...
         grandparent = parent_node.GetParent()
 
-        # build a new connecting branch
         branch_len = 0
         branch_len += sib.parent_branch[0].length
         branch_len += parent_node.parent_branch[0].length
         new_branch = branch.branch(branch_len)
         new_branch.addNode(sib)
         new_branch.addNode(grandparent)
-        
+
         sib.parent_branch[0] = new_branch
         gp_branch = parent_node.parent_branch[0]
-        
+
         for i in range(len(grandparent.child_branches)):
             if grandparent.child_branches[i] is gp_branch:
                 grandparent.child_branches[i] = new_branch
-
-        # remove the nodes from the tree's node-dictionary
-        #del tree.node_dict[this_node.name]
-        #del tree.node_dict[parent_node.name]
 
     def KeepOneLeaf(this_node):
 
@@ -708,10 +620,9 @@ class node:
 
         tree = this_node.tree
         leaves = this_node.leaf_nodes
-        f_leaves = filter(lambda i: not i.is_rep,leaves)
-        k_leaves = filter(lambda i: i.is_rep,leaves)
+        f_leaves = [i for i in leaves if not i.is_rep]
+        k_leaves = [i for i in leaves if i.is_rep]
 
-        # get filter counts
         for filt in this_node.tree.species_count.keys():
             leaf_dict[filt] = 0
         for leaf in f_leaves:
@@ -719,12 +630,10 @@ class node:
 
         if len(k_leaves) > 0:
             keep_leaves.append(k_leaves[0])
-        
-        # keep the eldest leaf (that isn't a representative of a
-        # sub-cluster)
+
         keep_leaf = f_leaves[0]
 
-        for leaf_ind in range(1,len(f_leaves)):
+        for leaf_ind in range(1, len(f_leaves)):
             this_leaf = f_leaves[leaf_ind]
             this_leaf.RemoveLeaf()
 
@@ -735,7 +644,7 @@ class node:
 
         return keep_leaves, leaf_dict
 
-    def DrawSubclusters(this_node,cluster_habitat,cluster_file):
+    def DrawSubclusters(this_node, cluster_habitat, cluster_file):
 
         if this_node.isLeaf():
             return
@@ -743,19 +652,19 @@ class node:
         this_habitat = this_node.habitat
         this_filter = this_node.max_filter
         kids = this_node.GetKids()
-        
+
         if this_node.cluster_root:
             for kid in kids:
-                kid.DrawSubclusters(this_habitat,cluster_file)
+                kid.DrawSubclusters(this_habitat, cluster_file)
             return
 
         if this_habitat is cluster_habitat:
 
             internal_line = this_node.PrintiTolInternal(10)
             cluster_file.write(internal_line + "\n")
-            
+
         for kid in kids:
-            kid.DrawSubclusters(cluster_habitat,cluster_file)
+            kid.DrawSubclusters(cluster_habitat, cluster_file)
 
     def GetLikDiffs(this_node):
 
@@ -790,11 +699,11 @@ class node:
         dad.threshold = sis.threshold + math.log(sis.GetTransProb(dad))
 
         return lik_diff, thresh_diff
-        
-    def GetTransProb(this_node,parent_node):
+
+    def GetTransProb(this_node, parent_node):
 
         if this_node.GetParent() is not parent_node:
-            print "not parent passed"
+            print("not parent passed")
             sys.exit(1)
 
         tree = this_node.tree
@@ -803,9 +712,9 @@ class node:
         t = this_node.parent_branch[0].length
 
         if this_node.habitat == parent_node.habitat:
-            tp = 1.0/h_num + (h_num-1)/h_num*math.exp(-h_num*mu*t)
+            tp = 1.0 / h_num + (h_num - 1) / h_num * math.exp(-h_num * mu * t)
         else:
-            tp = 1.0/h_num*(1-math.exp(-h_num*mu*t)) 
+            tp = 1.0 / h_num * (1 - math.exp(-h_num * mu * t))
 
         return tp
 
@@ -814,21 +723,20 @@ class node:
         this_str = ""
         this_str += str(this_node)
 
-        # states = this_node.tree.hidden_states
         color_hash = this_node.tree.color_hash
         this_state = this_node.species
 
-        rings = color_hash.keys()
+        rings = list(color_hash.keys())
         rings.sort()
         for ring in rings:
-            symbols = color_hash[ring].keys()
+            symbols = list(color_hash[ring].keys())
             symbols.sort()
             for symbol in symbols:
                 this_str += ","
                 if ring == "H":
                     this_str += str(0.0)
                 else:
-                    if symbol == this_state[int(ring)-1]:
+                    if symbol == this_state[int(ring) - 1]:
                         this_str += str(10.0)
                     else:
                         this_str += str(0.0)
@@ -842,29 +750,28 @@ class node:
         habitat = this_node.habitat
         states = this_node.tree.states
         s_dict = this_node.tree.migration_matrix[habitat]
-        rs_dict = dict(map(lambda i: (i[1],i[0]), s_dict.items()))
-        keys = rs_dict.keys()
+        rs_dict = dict(map(lambda i: (i[1], i[0]), s_dict.items()))
+        keys = list(rs_dict.keys())
         keys.sort()
         keys.reverse()
 
         state1 = rs_dict[keys[0]]
         state2 = rs_dict[keys[1]]
 
-        states = [state1,state2]
+        states = [state1, state2]
         vals = [keys[0], keys[1]]
 
         return states, keys
 
-    def PrintiTolInternal(this_node,R_size,nodes=None):
-        
+    def PrintiTolInternal(this_node, R_size, nodes=None):
+
         internal_line = ""
         if this_node is this_node.tree.root:
             return internal_line
 
         if nodes is None:
-            # find nodes to define this subtree
             node1 = this_node.GetALeaf(0)
-            node2 = this_node.GetALeaf(1)                
+            node2 = this_node.GetALeaf(1)
         else:
             node1 = nodes[0]
             if len(nodes) < 2:
@@ -875,7 +782,6 @@ class node:
         color_hash = this_node.tree.color_hash
         habitat_choice = this_node.habitat.split(' ')[-1]
 
-        # write out the results
         if node2 is not None:
             internal_line += str(node1) + "|"
             internal_line += str(node2)
@@ -883,11 +789,10 @@ class node:
             internal_line += str(node1)
         internal_line += ",R" + str(R_size)
 
-        # add zeros for all the states
-        rings = color_hash.keys()
+        rings = list(color_hash.keys())
         rings.sort()
         for ring in rings:
-            symbols = color_hash[ring].keys()
+            symbols = list(color_hash[ring].keys())
             symbols.sort()
             for symbol in symbols:
                 internal_line += ","
@@ -917,33 +822,29 @@ class node:
 
         return divergers
 
-    def ClusterTest(this_node,files,params):
-        
+    def ClusterTest(this_node, files, params):
+
         if this_node.isLeaf():
             this_node.div_tested = True
             return
 
-        # make sure this node is a divergence point
         if this_node.divergers is None:
-            print "no divergers in clustertest!"
+            print("no divergers in clustertest!")
             sys.exit(1)
 
-        # test that you've checked out all divergence nodes below
         divergers = this_node.divergers
 
         for div_node in divergers:
             if not div_node.div_tested:
-                div_node.ClusterTest(files,params)
+                div_node.ClusterTest(files, params)
                 div_node.div_tested = True
 
-        # see where the clusters are
-        this_node.ClusterFind(this_node.habitat,files,params)
+        this_node.ClusterFind(this_node.habitat, files, params)
 
         return
 
-    def ClusterFind(this_node,habitat,files,params):
+    def ClusterFind(this_node, habitat, files, params):
 
-        # return if you hit a leaf or another divergence node
         if len(this_node.leaf_nodes) < 1:
             return
         if this_node.habitat != habitat:
@@ -951,7 +852,6 @@ class node:
 
         is_cluster = False
 
-        # test first for homogeneity
         same_count = 0.0
         for leaf in this_node.leaf_nodes:
             if leaf.ML_state[this_node.habitat]:
@@ -959,18 +859,14 @@ class node:
 
         frac = same_count / len(this_node.leaf_nodes)
         if frac > 0.9:
-            # now, test likelihood:
             lik = this_node.likelihood
             thresh = this_node.threshold
 
-            # precision is about 8 points due to earlier
-            # conversion to string
-            lik_big = int(lik*math.pow(10,8))
-            thresh_big = int(thresh*math.pow(10,8))
+            lik_big = int(lik * math.pow(10, 8))
+            thresh_big = int(thresh * math.pow(10, 8))
             if lik_big > thresh_big:
                 is_cluster = True
 
-        # if is a cluster
         if is_cluster:
             cluster_file = files['cluster']
             cdist_file = files['cdist']
@@ -979,46 +875,40 @@ class node:
             this_node.cluster_root = True
 
             if params['cdist']:
-                # get the average distance between leaves in the cluster
                 avg_dist = this_node.GetAverageClusterDist()
                 cdist_file.write(str(avg_dist) + "\n")
-            
-            # remove leaf nodes from all upstream nodes
+
             parent.RemoveLeaves(this_node)
 
-            # subtract likelihood
             gdad = parent.GetParent()
             if gdad is not None:
                 lik_diff, thresh_diff = this_node.GetLikDiffs()
-                gdad.SubtractLikelihood(lik_diff,thresh_diff)
+                gdad.SubtractLikelihood(lik_diff, thresh_diff)
             internal_line = this_node.PrintiTolInternal(50)
             cluster_file.write(internal_line + "\n")
-            
+
         else:
             for kid in this_node.GetKids():
-                kid.ClusterFind(habitat,files,params)
+                kid.ClusterFind(habitat, files, params)
 
         return
-            
-    def UpPrune(this_node,files):
+
+    def UpPrune(this_node, files):
 
         tree = this_node.tree
         colors = tree.states
         prune_file = files['prune']
         bars_file = files['bar']
-        
-        # post-fix
+
         kids = this_node.GetKids()
         for kid in kids:
             kid.UpPrune(files)
 
-        # find clusters
         if not this_node.cluster_root:
             return
 
-        # remove all but one of the kids
         keep_leaves, leaf_dict = this_node.KeepOneLeaf()
-        internal_line = this_node.PrintiTolInternal(10,keep_leaves)
+        internal_line = this_node.PrintiTolInternal(10, keep_leaves)
         prune_file.write(internal_line + "\n")
 
         bar_str = ""
@@ -1030,21 +920,19 @@ class node:
                 bar_str += "\t" + str(leaf_dict[state])
         bars_file.write(bar_str + "\n")
 
-    # add a leaf back into a node's leaf nodes
-    def AddLeaf(this_node,leaf):
+    def AddLeaf(this_node, leaf):
         this_node.leaf_nodes.append(leaf)
         parent = this_node.GetParent()
         if parent is not None:
             parent.AddLeaf(leaf)
-    
-    # find the average distance between leaves in this cluster
+
     def GetAverageClusterDist(this_node):
 
         leaves = this_node.leaf_nodes
         total_dist = 0
         pair_count = 0
         for ind1 in range(len(leaves)):
-            for ind2 in range(ind1+1,len(leaves)):
+            for ind2 in range(ind1 + 1, len(leaves)):
                 dist = leaves[ind1].DistTo(leaves[ind2])[1]
                 total_dist += dist
                 pair_count += 1
@@ -1052,7 +940,7 @@ class node:
         avg_dist = total_dist / pair_count
         return avg_dist
 
-    def FulliTol(this_node,files):
+    def FulliTol(this_node, files):
 
         full_file = files['full']
         kids = this_node.GetKids()

--- a/example/adaptml.file
+++ b/example/adaptml.file
@@ -1,5 +1,5 @@
 tree = example/vibrio.hsp60.tree
-init_hab_num = 10
+init_hab_num = 16
 outgroup = 5S_OUTGROUP
 write_dir = example/output/
 rateopt = avg

--- a/example/likelihood.file
+++ b/example/likelihood.file
@@ -2,4 +2,4 @@ tree = example/vibrio.hsp60.tree
 outgroup = 5S_OUTGROUP
 write_dir = example/output/
 color = example/color.file
-thresh = 0.1
+thresh = 0.9999

--- a/habitats/trunk/AdaptML.py
+++ b/habitats/trunk/AdaptML.py
@@ -1,22 +1,23 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # AdaptML
 
 import os
 import sys
+import math
 import pdb
 import time
 import random
 
-from numpy.linalg import *
-from numpy.core import *
-from numpy.lib import *
 from numpy import *
+# Keep builtin sum accessible after `from numpy import *` shadows it.
+# numpy.sum on dict_views misbehaves in numpy 2.x.
+from builtins import sum as _builtin_sum
 
 import multitree
 import ML
 
-start_time = time.time()
-sys.setrecursionlimit(25000)
+start_time = time.perf_counter()
+sys.setrecursionlimit(50000)
 
 # load inputs #
 tree_filename = None
@@ -29,7 +30,7 @@ habitat_thresh = 0.10
 converge_thresh = 0.001
 
 inputs = sys.argv
-for ind in range(1,len(inputs)):
+for ind in range(1, len(inputs)):
     arg_parts = inputs[ind].split('=')
     code = arg_parts[0]
     arg = arg_parts[1]
@@ -51,15 +52,15 @@ for ind in range(1,len(inputs)):
         habitat_thresh = float(arg)
 
 # track stats
-stats_file = open(write_dir + '/stats.file','w')
+stats_file = open(write_dir + '/stats.file', 'w')
 
 # build the tree #
-print "\nBuilding Tree"
-tree_file = open(tree_filename,"r")
+print("\nBuilding Tree")
+tree_file = open(tree_filename, "r")
 tree_string = tree_file.read().strip()
 tree = multitree.multitree()
 tree.build(tree_string)
-if tree.root != None:
+if tree.root is not None:
     sys.stderr.write("Input tree is rooted.  Must use unrooted tree")
     sys.exit()
 tree_file.close()
@@ -76,14 +77,14 @@ for b in tree.branch_list:
 
 # how many species are there?
 species_dict = tree.species_count
-total_leaves = sum(species_dict.values())
+total_leaves = _builtin_sum(species_dict.values())
 habitat_list = []
-filter_list = species_dict.keys()
+filter_list = list(species_dict.keys())
 for i in range(hab_num):
     habitat_list.append("habitat " + str(i))
 
-# create O(n^3) habitat matrix
-print "Instantiating Habitat Matrix"
+# create habitat matrix
+print("Instantiating Habitat Matrix")
 habitat_matrix = {}
 for habitat in habitat_list:
     habitat_matrix[habitat] = {}
@@ -91,7 +92,7 @@ for habitat in habitat_list:
         habitat_matrix[habitat][filt] = random.random()
 
     # normalize
-    scale = sum(habitat_matrix[habitat].values())
+    scale = _builtin_sum(habitat_matrix[habitat].values())
     for filt in filter_list:
         habitat_matrix[habitat][filt] /= scale
 
@@ -99,48 +100,48 @@ score = -9999.99999999
 diff = 1.0
 old_diff = 1.0
 
-print "Learning Habitats:"
+print("Learning Habitats:")
 while 1:
     counter = 0
 
-    print "\t" + str(len(habitat_matrix)) + " habitats"
-    print "\tRefinement Steps [d(Habitat Score)]: "
+    print("\t" + str(len(habitat_matrix)) + " habitats")
+    print("\tRefinement Steps [d(Habitat Score)]: ")
     stats_str = ""
     stats_str += "counter\t"
-    stats_str += "habs\t"        
+    stats_str += "habs\t"
     stats_str += "ML score\t"
-    stats_str += "mu\t"        
-    stats_str += "\thabitat dist diff\t"        
+    stats_str += "mu\t"
+    stats_str += "\thabitat dist diff\t"
     stats_file.write(stats_str + "\n")
 
     while 1:
         stats_str = ""
         stats_str += str(counter) + "\t"
-        stats_str += str(len(habitat_matrix)) + "\t"        
+        stats_str += str(len(habitat_matrix)) + "\t"
         stats_str += str(score) + "\t"
-        stats_str += str(mu) + "\t"        
-        stats_str += str(diff) + "\t"        
+        stats_str += str(mu) + "\t"
+        stats_str += str(diff) + "\t"
         stats_file.write(stats_str + "\n")
         stats_file.flush()
-        print "\t\t" + str(counter) + "\t" + str(diff)
+        print("\t\t" + str(counter) + "\t" + str(diff))
 
         # wipe the likelihoods off of the tree
         ML.TreeWipe(tree)
 
         # learn the likelihoods
-        ML.LearnLiks(tree,mu,habitat_matrix)
+        ML.LearnLiks(tree, mu, habitat_matrix)
 
         # estimate the states (by making each node trifurcating...)
-        ML.EstimateStates(tree.a_node,habitat_matrix)
-        
+        ML.EstimateStates(tree.a_node, habitat_matrix)
+
         # upgrade guesses for mu and habitat matrix
         this_migrate = habitat_matrix
-        mu, habitat_matrix = ML.LearnRates(tree,mu,habitat_matrix,rateopt)
+        mu, habitat_matrix = ML.LearnRates(tree, mu, habitat_matrix, rateopt)
         new_migrate = habitat_matrix
 
         # stop?
         old_diff = diff
-        score, diff = ML.CheckConverge(tree,new_migrate,this_migrate)
+        score, diff = ML.CheckConverge(tree, new_migrate, this_migrate)
 
         if diff < converge_thresh:
             break
@@ -148,8 +149,8 @@ while 1:
         # this should break the loop if you end up bouncing back and
         # forth between the same values
         sig_figs = 8
-        diff1 = math.floor(diff*math.pow(10,sig_figs))
-        diff2 = math.floor(old_diff*math.pow(10,sig_figs))        
+        diff1 = math.floor(diff * math.pow(10, sig_figs))
+        diff2 = math.floor(old_diff * math.pow(10, sig_figs))
         if diff1 > 0:
             if diff1 == diff2:
                 break
@@ -160,7 +161,7 @@ while 1:
     #########################
     # remove similar groups #
     #########################
-    print "Removing Redundant Habitats"
+    print("Removing Redundant Habitats")
     new_habitats = {}
     for habitat_1 in habitat_matrix:
         old_habitat = habitat_matrix[habitat_1]
@@ -170,7 +171,7 @@ while 1:
             score = 0
             for this_filter in old_habitat:
                 diff = old_habitat[this_filter] - new_habitat[this_filter]
-                score += math.pow(diff,2)
+                score += math.pow(diff, 2)
             if score < habitat_thresh:
                 add_habitat = False
         if add_habitat:
@@ -180,8 +181,9 @@ while 1:
     habitat_matrix = new_habitats
     if len(habitat_matrix) < 2:
         break
-print "Learned " + str(len(habitat_matrix)) + " habitats",
-print "in " + str(time.clock()) + " seconds"
+
+print("Learned " + str(len(habitat_matrix)) + " habitats", end=' ')
+print("in {:.2f} seconds".format(time.perf_counter() - start_time))
 stats_file.write("\nEnd Of Run\n")
 
 ############################
@@ -197,12 +199,16 @@ for b in tree.branch_list:
         tree.rootify(b)
 
 # write out the results
-mu_file = open(write_dir + '/mu.val','w')
+mu_file = open(write_dir + '/mu.val', 'w')
 mu_file.write(str(mu))
 mu_file.close()
 
-habitat_file = open(write_dir + '/habitat.matrix','w')
-habitat_file.write(str(habitat_matrix))
+# cast to plain Python floats so downstream `eval()` doesn't need `np.float64`
+habitat_matrix_plain = {
+    str(h): {str(k): float(v) for k, v in habitat_matrix[h].items()}
+    for h in habitat_matrix
+}
+habitat_file = open(write_dir + '/habitat.matrix', 'w')
+habitat_file.write(str(habitat_matrix_plain))
 habitat_file.close()
 stats_file.close()
-

--- a/habitats/trunk/ML.py
+++ b/habitats/trunk/ML.py
@@ -6,32 +6,33 @@ import math
 import pdb
 
 from numpy import *
-from numpy.matlib import *
 from scipy.optimize import fminbound
 
-def CheckConverge(tree,new_migrate,this_migrate):
+
+def CheckConverge(tree, new_migrate, this_migrate):
 
     total_prob = 0
     for i in tree.internal_node_list:
         for j in i.ML_probs:
-            total_prob += sum(i.ML_probs[j].values())
+            total_prob += sum(list(i.ML_probs[j].values()))
 
-    total_prob /= len(tree.internal_node_list)*len(i.ML_probs)
+    total_prob /= len(tree.internal_node_list) * len(i.ML_probs)
 
     diff = 0
     for habitat in this_migrate:
-        for filter in this_migrate[habitat]:
-            p1 = this_migrate[habitat][filter]
-            p2 = new_migrate[habitat][filter]            
-            diff += abs(p1-p2)
+        for filter_ in this_migrate[habitat]:
+            p1 = this_migrate[habitat][filter_]
+            p2 = new_migrate[habitat][filter_]
+            diff += abs(p1 - p2)
 
-    diff /= len(this_migrate)*len(this_migrate[habitat])
+    diff /= len(this_migrate) * len(this_migrate[habitat])
 
     return total_prob, diff
-        
-def EstimateStates(this_node,migration_matrix):
 
-    habitats = migration_matrix.keys()
+
+def EstimateStates(this_node, migration_matrix):
+
+    habitats = list(migration_matrix.keys())
 
     if len(this_node.ML_probs) == 1:
 
@@ -40,7 +41,7 @@ def EstimateStates(this_node,migration_matrix):
             this_prob = migration_matrix[habitat][this_filter]
             this_node.ML_state[habitat] = this_prob
 
-        overall_lik = sum(this_node.ML_state.values())
+        overall_lik = sum(list(this_node.ML_state.values()))
         for habitat in this_node.ML_state:
             this_node.ML_state[habitat] /= overall_lik
 
@@ -57,30 +58,23 @@ def EstimateStates(this_node,migration_matrix):
                 states[habitat] += this_node.ML_probs[kid_node][habitat]
 
         # scale log liks and convert to probs
-        sum_prob = sum(exp(array(states.values())))
+        sum_prob = sum(exp(array(list(states.values()))))
 
-        min_float =  math.exp(-745)
+        min_float = math.exp(-745)
         if sum_prob < min_float:
             sum_prob = min_float
 
         this_node.sum_lik = sum_prob
 
         for species in states:
-            this_node.ML_state[species] = math.exp(states[species])/sum_prob
-
-        # print
-        # print this_node
-        # print this_node.ML_state
-
-        #if "1_1" in this_node.name:
-        #    if "F_1" in this_node.name:
-        #        pdb.set_trace()
+            this_node.ML_state[species] = math.exp(states[species]) / sum_prob
 
     for kid_node in this_node.other_nodes:
         if len(kid_node.ML_state) < 1:
-            EstimateStates(kid_node,migration_matrix)
+            EstimateStates(kid_node, migration_matrix)
 
-def LearnMR(tree,migration_matrix,mu):
+
+def LearnMR(tree, migration_matrix, mu):
 
     new_migration_matrix = {}
     for i in migration_matrix:
@@ -89,7 +83,7 @@ def LearnMR(tree,migration_matrix,mu):
             new_migration_matrix[i][j] = math.exp(-24)
 
     hab_num = float(len(migration_matrix))
-    
+
     for leaf in tree.leaf_node_list:
 
         # identify the parent
@@ -101,14 +95,8 @@ def LearnMR(tree,migration_matrix,mu):
 
         this_filter = leaf.species
 
-        """
-        for habitat in parent_node.ML_state:
-            val = parent_node.ML_state[habitat]
-            new_migration_matrix[habitat][this_filter] += val
-        """
-
-        p_xx = 1.0/hab_num + (hab_num-1)/hab_num*math.exp(-hab_num*mu*t)
-        p_xy = 1.0/hab_num*(1-math.exp(-hab_num*mu*t)) 
+        p_xx = 1.0 / hab_num + (hab_num - 1) / hab_num * math.exp(-hab_num * mu * t)
+        p_xy = 1.0 / hab_num * (1 - math.exp(-hab_num * mu * t))
 
         for parent_habitat in parent_node.ML_state:
             for leaf_habitat in leaf.ML_state:
@@ -117,20 +105,21 @@ def LearnMR(tree,migration_matrix,mu):
                     trans_prob = p_xx
                 else:
                     trans_prob = p_xy
-                prob = trans_prob*parent_node.ML_state[parent_habitat]
+                prob = trans_prob * parent_node.ML_state[parent_habitat]
                 new_migration_matrix[leaf_habitat][this_filter] += prob
 
     for this_habitat in new_migration_matrix:
-        scale = sum(new_migration_matrix[this_habitat].values())
+        scale = sum(list(new_migration_matrix[this_habitat].values()))
         for this_filter in new_migration_matrix[this_habitat]:
             new_migration_matrix[this_habitat][this_filter] /= scale
 
     return new_migration_matrix
 
-def LearnRates(tree,mu,migration_matrix,rateopt):
+
+def LearnRates(tree, mu, migration_matrix, rateopt):
 
     # update the migration matrix
-    migration_matrix_opt = LearnMR(tree,migration_matrix,mu)
+    migration_matrix_opt = LearnMR(tree, migration_matrix, mu)
 
     # update the transition rate
     mu_0 = NodeRate(tree)
@@ -139,53 +128,50 @@ def LearnRates(tree,mu,migration_matrix,rateopt):
         return mu_0, migration_matrix_opt
     elif rateopt == 'num':
         # optimize rate numerically
-        mu_opt = fminbound(TestMu,0,mu_0*3,args=(tree,migration_matrix),xtol=1e-2)
-        if mu_opt > mu_0*2.75:
-            print "look into fminbound bounds"
+        mu_opt = fminbound(TestMu, 0, mu_0 * 3, args=(tree, migration_matrix), xtol=1e-2)
+        if mu_opt > mu_0 * 2.75:
+            print("look into fminbound bounds")
             sys.exit(1)
 
         # put things back the way they used to be (need to do, since
         # there's a treewipe inside of testmu)
         TreeWipe(tree)
-        LearnLiks(tree,mu,migration_matrix)
-        EstimateStates(tree.a_node,migration_matrix)
+        LearnLiks(tree, mu, migration_matrix)
+        EstimateStates(tree.a_node, migration_matrix)
 
         return mu_opt, migration_matrix_opt
 
-def TestMu(mu,tree,migration_matrix):
+
+def TestMu(mu, tree, migration_matrix):
 
     TreeWipe(tree)
-    LearnLiks(tree,mu,migration_matrix)
-    score, diff = CheckConverge(tree,migration_matrix,migration_matrix)
-
-    # since you're trying to minimize, return inverse ...
+    LearnLiks(tree, mu, migration_matrix)
+    score, diff = CheckConverge(tree, migration_matrix, migration_matrix)
 
     return -score
 
-def LearnRootedRates(tree,eigs,Q_matrix):
+
+def LearnRootedRates(tree, eigs, Q_matrix):
 
     species_key = eigs["key"]
 
-    Q_zero = matrix(zeros((len(species_key),len(species_key))))
-    Q, total_array = NodeRootedRate(tree.root,eigs)
+    Q_zero = matrix(zeros((len(species_key), len(species_key))))
+    Q, total_array = NodeRootedRate(tree.root, eigs)
 
     for i in range(len(total_array)):
-        Q[i,:] /= total_array[i]
+        Q[i, :] /= total_array[i]
 
     return Q
 
+
 def NodeRate(tree):
 
-    # think of a really small number
     eps = math.exp(-10)
     same_count = 0
     total_dist = 0
     counter = 0
 
     for branch in tree.branch_list:
-
-        # maybe we shouldn't include leaf nodes (they probably make it
-        # look like there are more changes than there ought to be)
 
         node1 = branch.ends[0]
         node2 = branch.ends[1]
@@ -207,7 +193,7 @@ def NodeRate(tree):
             if m1[i] > max1:
                 max1_state = i
                 max1 = m1[i]
-        
+
         for i in m2:
             if m2[i] > max2:
                 max2_state = i
@@ -220,21 +206,27 @@ def NodeRate(tree):
         total_dist += branch.length
 
     hab_num = float(len(m1))
-    t = total_dist/counter
-    dist = 1 - float(same_count)/counter
+    t = total_dist / counter
+    dist = 1 - float(same_count) / counter
 
-    inner = 1 - dist*hab_num/(hab_num-1)
+    inner = 1 - dist * hab_num / (hab_num - 1)
+
+    # guard against numerical edge cases when there are no inferred transitions
+    if inner <= 0:
+        inner = math.exp(-10)
 
     this_mu = -math.log(inner) / (hab_num * t)
 
     return this_mu
 
-def LearnLiks(tree,mu,migration_matrix):
 
-    # compute likelihoods for all internal nodes, keyed by child nodes 
+def LearnLiks(tree, mu, migration_matrix):
+
+    # compute likelihoods for all internal nodes, keyed by child nodes
     for node in tree.internal_node_list:
         for kid in node.other_nodes:
-            MLNode(node,kid,mu,migration_matrix)
+            MLNode(node, kid, mu, migration_matrix)
+
 
 def TreeWipe(tree):
 
@@ -245,16 +237,8 @@ def TreeWipe(tree):
         i.ML_probs = {}
         i.ML_state = {}
 
-    """
-    this_node.old_state = this_node.ML_state.copy()
-    this_node.ML_probs = {}
-    this_node.ML_state = {}
-    for i in this_node.other_nodes:
-        if len(i.ML_state) > 0:
-            TreeWipe(i)
-    """
-        
-def MLNode(this_node,kid_node,mu,migration_matrix):
+
+def MLNode(this_node, kid_node, mu, migration_matrix):
 
     # no need to recurse if you've already solved this problem
     if kid_node in this_node.ML_probs:
@@ -273,11 +257,11 @@ def MLNode(this_node,kid_node,mu,migration_matrix):
         return
 
     # if not a leaf, need to obtain probabilities of child values:
-    child_nodes = filter(lambda i: i is not this_node, kid_node.other_nodes)
+    child_nodes = [i for i in kid_node.other_nodes if i is not this_node]
     if len(child_nodes) < 1:
-        child_nodes = [None,None]
-    MLNode(kid_node,child_nodes[0],mu,migration_matrix)
-    MLNode(kid_node,child_nodes[1],mu,migration_matrix)    
+        child_nodes = [None, None]
+    MLNode(kid_node, child_nodes[0], mu, migration_matrix)
+    MLNode(kid_node, child_nodes[1], mu, migration_matrix)
 
     # now, work out transition probabilities
     if kid_node in this_node.branch_dict:
@@ -286,10 +270,10 @@ def MLNode(this_node,kid_node,mu,migration_matrix):
         t = kid_node.branch_dict[this_node].length
 
     hab_num = float(len(migration_matrix))
-    p_xx = 1.0/hab_num + (hab_num-1)/hab_num*math.exp(-hab_num*mu*t)
-    p_xy = 1.0/hab_num*(1-math.exp(-hab_num*mu*t)) 
+    p_xx = 1.0 / hab_num + (hab_num - 1) / hab_num * math.exp(-hab_num * mu * t)
+    p_xy = 1.0 / hab_num * (1 - math.exp(-hab_num * mu * t))
 
-    habitats = migration_matrix.keys()
+    habitats = list(migration_matrix.keys())
 
     # for each of the current nodes possible states
     for this_habitat in habitats:
@@ -308,8 +292,8 @@ def MLNode(this_node,kid_node,mu,migration_matrix):
             prob += math.log(trans_prob)
 
             # handle case at leaves
-            if child_nodes == [None,None]:
-                prob +=  kid_node.ML_probs[None][kid_habitat]
+            if child_nodes == [None, None]:
+                prob += kid_node.ML_probs[None][kid_habitat]
             else:
                 prob += kid_node.ML_probs[child_nodes[0]][kid_habitat]
                 prob += kid_node.ML_probs[child_nodes[1]][kid_habitat]
@@ -318,7 +302,3 @@ def MLNode(this_node,kid_node,mu,migration_matrix):
         this_node.ML_probs[kid_node][this_habitat] = math.log(sum_prob)
 
     return
-
-    
-    
-

--- a/habitats/trunk/branch.py
+++ b/habitats/trunk/branch.py
@@ -1,48 +1,47 @@
-import copy;
+import copy
+
 
 class branch:
 
-    def __init__(self,length):
-        self.ends = []                  # nodes connected to
-        self.length = float(length)	# length (can change during rooting)
-        self.immutable_length = self.length # don't ever change this
-        self.visited = False            # used for traversing the tree
+    def __init__(self, length):
+        self.ends = []                       # nodes connected to
+        self.length = float(length)          # length (can change during rooting)
+        self.immutable_length = self.length  # don't ever change this
+        self.visited = False                 # used for traversing the tree
 
     def __repr__(self):
+        if len(self.ends) == 2:
+            print_string = "(" + self.ends[0].name + ","
+            print_string += self.ends[1].name + "):" + str(self.immutable_length)
+        else:
+            print_string = ":" + str(self.immutable_length)
+        return print_string
 
-	if len(self.ends) == 2:
-	    print_string = "(" + self.ends[0].name + "," 
-	    print_string += self.ends[1].name + "):" + str(self.immutable_length)
-	else:
-	    print_string = ":" + str(self.immutable_length)
-	return print_string
-	
-    def addNode(self,node):
-	self.ends.append(node)
-	node.branch_list.append(self)
+    def addNode(self, node):
+        self.ends.append(node)
+        node.branch_list.append(self)
 
     # recursion for finding all of the branches in an unrooted tree
-    def findBranches(self,all_branches):
-	
-	all_branches.append(self)
-	self.visited = True
+    def findBranches(self, all_branches):
 
-	for node in self.ends:
-	    for brch in node.branch_list:
-		if not brch.visited:
-		    all_branches = brch.findBranches(all_branches)
+        all_branches.append(self)
+        self.visited = True
 
-	return all_branches
+        for node in self.ends:
+            for brch in node.branch_list:
+                if not brch.visited:
+                    all_branches = brch.findBranches(all_branches)
 
-    # recusion to dump all the branches of an unrooted tree into the
+        return all_branches
+
+    # recursion to dump all the branches of an unrooted tree into the
     # provided dictionary
-    def FillBranchDict(this_branch,branch_dict):
+    def FillBranchDict(this_branch, branch_dict):
 
         for parent_node in this_branch.ends:
             for branch in parent_node.branch_list:
                 if branch is not this_branch:
                     for child_node in branch.ends:
                         if child_node is not parent_node:
-                            print child_node
-                            print child_node.leaves
-            
+                            print(child_node)
+                            print(child_node.leaves)

--- a/habitats/trunk/multitree.py
+++ b/habitats/trunk/multitree.py
@@ -8,28 +8,29 @@ import random
 import math
 import sys
 import pdb
+from functools import reduce
 
 from numpy import *
 
 import node
 import branch
 
+
 class multitree:
-    
-    # recursive module for building unrooted trees from newick-notated
-    # strings.  
+
+    # recursive module for building unrooted trees from newick-notated strings.
     def __init__(self):
-	self.build_queue = []
+        self.build_queue = []
         self.a_node = None
-	self.a_branch = None
-	self.root = None
-	self.root_branch = None
-	self.num_dups = 0
-	self.num_losses = 0
-	self.num_xfers = 0
-	self.event_queue = []           # keep running list of events
-	self.node_dict = dict()
-	self.mapping_hash = dict()      # store node mappings
+        self.a_branch = None
+        self.root = None
+        self.root_branch = None
+        self.num_dups = 0
+        self.num_losses = 0
+        self.num_xfers = 0
+        self.event_queue = []           # keep running list of events
+        self.node_dict = dict()
+        self.mapping_hash = dict()      # store node mappings
         self.loss_dict = {}             # cache res from countlosses
         self.lca_dict = {}
         self.rec_dict = {}
@@ -39,28 +40,26 @@ class multitree:
         self.leaf_node_list = []
         self.branch_list = []
         self.liks = None
-        
+
     # print the tree (intended for rooted trees)
     def __repr__(self):
-	if self.root == None:
-	    return "not rooted"
-	else:
-	    newickString = ""
-	    return self.root.treePrint(newickString)
-
-    # sneaky way of labeling probabilities - put them into the
-    # bootstraps 
-    def PrintLabeledBoots(self):
-
-        # rank the nodes according to their summed likelihoods
-        all_liks = array(map(lambda i: i.sum_lik,self.internal_node_list))
-        self.liks = all_liks
-
-        if self.root == None:
+        if self.root is None:
             return "not rooted"
         else:
             newickString = ""
-            return self.root.BootPrint(newickString,1)
+            return self.root.treePrint(newickString)
+
+    # sneaky way of labeling probabilities - put them into the bootstraps
+    def PrintLabeledBoots(self):
+
+        all_liks = array([i.sum_lik for i in self.internal_node_list])
+        self.liks = all_liks
+
+        if self.root is None:
+            return "not rooted"
+        else:
+            newickString = ""
+            return self.root.BootPrint(newickString, 1)
 
     # get a list of species
     def GetSpeciesDict(self):
@@ -76,33 +75,32 @@ class multitree:
         return self.species_count
 
     # hijack old build, so as to give opportunity to remove bootstraps
-    # ... 
-    def build(self,newick):
+    def build(self, newick):
 
         # remove any bootstraps from newick
-        p = re.compile('\)[\d\.]+:')
-        newick = p.sub('):',newick)
-        self.RecursiveBuild(newick)  
+        p = re.compile(r'\)[\d\.]+:')
+        newick = p.sub('):', newick)
+        self.RecursiveBuild(newick)
 
-    def RecursiveBuild(self,newick):
+    def RecursiveBuild(self, newick):
 
-	# handle the case when you reach a trifurcating node (so
-	# unrooted), by looking for when you've got a stretch of 2
-	# colons unseparated by a parenthesis
-	colon_match1 = re.findall(':',newick)
-	colon_match2 = re.findall(':[^\)]*:[^\)]*:',newick)
+        # handle the case when you reach a trifurcating node (so unrooted),
+        # by looking for when you've got a stretch of 2 colons unseparated by
+        # a parenthesis
+        colon_match1 = re.findall(':', newick)
+        colon_match2 = re.findall(r':[^\)]*:[^\)]*:', newick)
 
-	# if you reach a root
-	if len(colon_match1) == 1:
+        # if you reach a root
+        if len(colon_match1) == 1:
 
-	    root_node = self.build_queue[0]
-	    
-	    for kid_branches in root_node.branch_list:
-		root_node.child_branches.append(kid_branches)
+            root_node = self.build_queue[0]
+
+            for kid_branches in root_node.branch_list:
+                root_node.child_branches.append(kid_branches)
 
             # do rooted stuff
-	    self.root = root_node
-	    self.root.imposeHierarchy()
+            self.root = root_node
+            self.root.imposeHierarchy()
             self.labelSubtrees()
             self.Get_Subnodes()
             self.root.Fill_Node_Dict()
@@ -110,22 +108,18 @@ class multitree:
         # handle case of a tree with only 2 nodes:
         elif len(colon_match1) == 2:
 
-	    # find an innermost set of parentheses:
-            regex = re.search('\([^\(\)]*\)',newick).span()
-	    clade = newick[regex[0]+1:regex[1]-1]
+            regex = re.search(r'\([^\(\)]*\)', newick).span()
+            clade = newick[regex[0] + 1:regex[1] - 1]
 
-	    # split up the clade
-	    children = re.split(',',clade)
-	    son = children[0]
-	    daughter = children[1]
+            children = re.split(',', clade)
+            son = children[0]
+            daughter = children[1]
 
-            # build node1
             node1 = self.BuildNode(son)
             node2 = self.BuildNode(daughter)
 
-	    # unite the two nodes
-	    center_node = node1.unite(node2)
-            
+            center_node = node1.unite(node2)
+
             # create a fake node:
             dummy_node = self.BuildNode("dummy_node:0.1")
             dummy_node.branch_list = []
@@ -136,49 +130,39 @@ class multitree:
             self.a_node = dummy_node
             center_node.UnrootedLeaving()
 
-	# handle the trifurcating node of an unrooted tree
-	elif len(colon_match1) == 3 and len(colon_match2) > 0:
-
-            # note that this updated block can handle trees with leaf
-            # count >= 3
+        # handle the trifurcating node of an unrooted tree
+        elif len(colon_match1) == 3 and len(colon_match2) > 0:
 
             # pull out the first node
-            regex = re.search('\([^,]*,',newick).span()
-            first_leaf = newick[regex[0]+1:regex[1]-1]
+            regex = re.search(r'\([^,]*,', newick).span()
+            first_leaf = newick[regex[0] + 1:regex[1] - 1]
 
-            ####newick = re.sub(first_leaf + ',','',newick)
-            newick = newick.replace(first_leaf + ',','')
+            newick = newick.replace(first_leaf + ',', '')
 
             first_node = self.BuildNode(first_leaf)
 
-            # first_node.branch_list = []
-            # don't need to worry about clearing, since we'll be
-            # adding branches anyway later down in this block.
             self.build_queue.append(first_node)
 
-	    # join the last 2 nodes:
-            regex = re.search('\(.*,[^\)]*\);',newick).span()
-            clade = newick[regex[0]+1:regex[1]-2]
+            # join the last 2 nodes:
+            regex = re.search(r'\(.*,[^\)]*\);', newick).span()
+            clade = newick[regex[0] + 1:regex[1] - 2]
 
-            # split up the clade
-            children = re.split(',',clade)
+            children = re.split(',', clade)
             son = children[0]
             daughter = children[1]
 
-            # build two nodes and join
             node1 = self.BuildNode(son)
             node2 = self.BuildNode(daughter)
             center_node = node1.unite(node2)
 
             # finally, join this new node with the remaining node:
             last_node = self.build_queue[0]
-            regex = re.search(':[^,]*,',newick).span()
+            regex = re.search(r':[^,]*,', newick).span()
             last_node.myBranch.addNode(center_node)
 
             self.a_branch = last_node.myBranch
 
-            # do some unrooted stuff, making sure you don't begin on a
-            # leaf. 
+            # do some unrooted stuff, making sure you don't begin on a leaf.
             if len(self.a_branch.ends[0].branch_list) == 3:
                 self.a_node = self.a_branch.ends[0]
                 self.a_branch.ends[0].UnrootedLeaving()
@@ -186,39 +170,33 @@ class multitree:
                 self.a_node = self.a_branch.ends[1]
                 self.a_branch.ends[1].UnrootedLeaving()
 
-	else:
+        else:
 
-	    # find an innermost set of parentheses:
-            search_res = re.search('\([^\(\)]*\):',newick)
+            search_res = re.search(r'\([^\(\)]*\):', newick)
             if search_res is None:
                 pdb.set_trace()
-	    regex = search_res.span()
-	    clade = newick[regex[0]+1:regex[1]-2]
+            regex = search_res.span()
+            clade = newick[regex[0] + 1:regex[1] - 2]
 
-	    # split up the clade
-	    children = re.split(',',clade)
-	    son = children[0]
-	    daughter = children[1]
+            children = re.split(',', clade)
+            son = children[0]
+            daughter = children[1]
 
-            # build nodes and unite
             node1 = self.BuildNode(son)
             node2 = self.BuildNode(daughter)
-	    center_node = node1.unite(node2)
+            center_node = node1.unite(node2)
 
-	    # replace the matched string with the new node:
-	    new_newick = newick[0:regex[0]]
-	    new_newick += center_node.name
-	    new_newick += newick[regex[1]-1:]
+            new_newick = newick[0:regex[0]]
+            new_newick += center_node.name
+            new_newick += newick[regex[1] - 1:]
 
-	    # add the new node to the queue of extant nodes
-	    self.build_queue.append(center_node)
+            self.build_queue.append(center_node)
 
-	    # recurse
-	    self.RecursiveBuild(new_newick)
+            self.RecursiveBuild(new_newick)
 
     # create a new node:
-    def BuildNode(this_tree,node_string):
-        splitSon = re.split(':',node_string)
+    def BuildNode(this_tree, node_string):
+        splitSon = re.split(':', node_string)
 
         # see if anyone in the queue has the same name
         node1match = False
@@ -229,8 +207,8 @@ class multitree:
                 node1match = True
                 break
         if node1match is not True:
-            node1 = node.node(splitSon[0],this_tree)
-            this_tree.leaf_count += 1   # another leaf added to tree 
+            node1 = node.node(splitSon[0], this_tree)
+            this_tree.leaf_count += 1   # another leaf added to tree
 
         node1.addBranch(splitSon[1])
 
@@ -238,49 +216,44 @@ class multitree:
 
     # label the subtrees
     def labelSubtrees(self):
+        if self.root is None:
+            print("you're trying to label an unrooted tree")
+        else:
+            self.root.subtreeLabel()
 
-	if self.root == None:
-	    print "you're trying to label an unrooted tree"
-	else:
-	    self.root.subtreeLabel()
-
-    # relabel the subtrees and rename nodes following transfer-induced
-    # shuffling
+    # relabel the subtrees and rename nodes following transfer-induced shuffling
     def relabelSubtrees(self):
-
-	if self.root == None:
-	    print "you're trying to label an unrooted tree"
-	else:
-	    self.root.subtreeReLabel()
-
+        if self.root is None:
+            print("you're trying to label an unrooted tree")
+        else:
+            self.root.subtreeReLabel()
 
     # get all subnodes (useful for finding LCAs)
     def Get_Subnodes(self):
-	self.root.Find_Subnodes()
+        self.root.Find_Subnodes()
 
     # concatentate and print two trees' queues
-    def Print_Event_Queue(tree1,tree2):
-	
-	event_q = []
-	event_q.extend(tree1.event_queue)
-	event_q.extend(tree2.event_queue)
-	
-	for i in event_q:
-	    print i
+    def Print_Event_Queue(tree1, tree2):
+        event_q = []
+        event_q.extend(tree1.event_queue)
+        event_q.extend(tree2.event_queue)
 
-    def rootify(self,center_branch):
+        for i in event_q:
+            print(i)
 
-	# remember the old branch:
-	self.root_branch = center_branch
+    def rootify(self, center_branch):
 
-	# create a new node
-	center_name = center_branch.ends[0].name
-	center_name += "-" + center_branch.ends[1].name
-	center_node = node.node(center_name,self)
-	self.root = center_node
-	
-        # in order to "mid-point root" need to find maximum distance
-        # from leaf in each subtree to the root
+        # remember the old branch:
+        self.root_branch = center_branch
+
+        # create a new node
+        center_name = center_branch.ends[0].name
+        center_name += "-" + center_branch.ends[1].name
+        center_node = node.node(center_name, self)
+        self.root = center_node
+
+        # in order to "mid-point root" need to find maximum distance from
+        # leaf in each subtree to the root
         node_1 = center_branch.ends[0]
         node_2 = center_branch.ends[1]
         leaves_1 = node_1.name_dict[node_2]
@@ -289,21 +262,21 @@ class multitree:
         max_dist_2 = 0.0
         node_list = self.leaf_node_list
         for leaf_s in leaves_1:
-            leaf = [leaf_node for leaf_node in node_list if leaf_node.name is leaf_s][0]
+            leaf = [leaf_node for leaf_node in node_list if leaf_node.name == leaf_s][0]
             leaf_dist = leaf.DistTo(node_1)[1]
             if leaf_dist > max_dist_1:
                 max_dist_1 = leaf_dist
         for leaf_s in leaves_2:
-            leaf = [leaf_node for leaf_node in node_list if leaf_node.name is leaf_s][0]
+            leaf = [leaf_node for leaf_node in node_list if leaf_node.name == leaf_s][0]
             leaf_dist = leaf.DistTo(node_2)[1]
             if leaf_dist > max_dist_2:
                 max_dist_2 = leaf_dist
 
         # figure out how long to make the branches
         cent_dist = center_branch.length
-        cent_dist_2 = float(max_dist_1 - max_dist_2 + cent_dist)/2
+        cent_dist_2 = float(max_dist_1 - max_dist_2 + cent_dist) / 2
         cent_dist_1 = cent_dist - cent_dist_2
-        
+
         # account for center branch not being long enough
         min_dist = 0.00001
         if cent_dist_1 < min_dist:
@@ -312,23 +285,23 @@ class multitree:
         if cent_dist_2 < min_dist:
             cent_dist_2 = min_dist
             cent_dist_1 = cent_dist - min_dist
-            
-	# give it children branches
-	child1 = branch.branch(cent_dist_1)
-	child1.addNode(center_node)
-	child1.addNode(node_1)
-	child2 = branch.branch(cent_dist_2)
-	child2.addNode(center_node)
-	child2.addNode(node_2)
-	center_node.child_branches.append(child1)
-	center_node.child_branches.append(child2)
 
-	# erase the original branch from the child nodes branch_list
-	for kids in center_branch.ends:
-	    kids.branch_list.remove(center_branch)
+        # give it children branches
+        child1 = branch.branch(cent_dist_1)
+        child1.addNode(center_node)
+        child1.addNode(node_1)
+        child2 = branch.branch(cent_dist_2)
+        child2.addNode(center_node)
+        child2.addNode(node_2)
+        center_node.child_branches.append(child1)
+        center_node.child_branches.append(child2)
 
-	# impose a hierarchy from the root
-	center_node.imposeHierarchy()
+        # erase the original branch from the child nodes branch_list
+        for kids in center_branch.ends:
+            kids.branch_list.remove(center_branch)
+
+        # impose a hierarchy from the root
+        center_node.imposeHierarchy()
         self.labelSubtrees()
         self.Get_Subnodes()
         self.root.Fill_Node_Dict()
@@ -336,23 +309,23 @@ class multitree:
     # unroot a tree
     def Unroot(self):
 
-        center_length = reduce(lambda i,j:i.length+j.length,self.root.child_branches)
-	self.root.NodeWipe()
+        center_length = reduce(lambda i, j: i.length + j.length, self.root.child_branches)
+        self.root.NodeWipe()
 
         # new center branch
         center_branch = branch.branch(center_length)
         self.a_branch = center_branch
 
-	# find the two kids 
-	kids = []
-	for kid_branches in self.root.branch_list:
+        # find the two kids
+        kids = []
+        for kid_branches in self.root.branch_list:
             for kid_nodes in kid_branches.ends:
-               if kid_nodes != self.root:
+                if kid_nodes != self.root:
 
-                   center_branch.addNode(kid_nodes)
-                   kid_nodes.myBranch = center_branch
-                   kid_nodes.branch_list.remove(kid_branches)
-                   kids.append(kid_nodes)
+                    center_branch.addNode(kid_nodes)
+                    kid_nodes.myBranch = center_branch
+                    kid_nodes.branch_list.remove(kid_branches)
+                    kids.append(kid_nodes)
 
         # do unrooted tree stuff
         if len(kids[0].branch_list) == 3:
@@ -363,4 +336,3 @@ class multitree:
         self.a_node.UnrootedLeaving()
         self.branch_list.remove(self.root_branch)
         self.root_branch = center_branch
-        

--- a/habitats/trunk/node.py
+++ b/habitats/trunk/node.py
@@ -2,54 +2,54 @@ import random
 import re
 import copy
 import sys
+import math
 import pdb
 
 from numpy import *
-from sets import Set
 
 import multitree
 import branch
 
+
 class node:
 
-    def __init__(self,name,arbre):
+    def __init__(self, name, arbre):
 
-        self.name_backup = name # argh, i need to refactor
+        self.name_backup = name  # argh, i need to refactor
         self.name = name
 
         # assign species names by stripping '.X' or '_X'
         match_str = re.compile(r'[\._]\w*-')
-        name = match_str.sub('-',name,0)
+        name = match_str.sub('-', name, 0)
         # catch trailers
         match_str = re.compile(r'[\._]\w*')
-        species = match_str.sub('',name,0)
+        species = match_str.sub('', name, 0)
 
         self.species = species
         self.perturb_species = species
-	self.range = []
-	self.range.append(self.species)
+        self.range = []
+        self.range.append(self.species)
         self.tree = arbre
-	self.lca_scores = dict()        # keep track of lca scores
-	self.event_str = dict()         # keep track of events for each lca
-	    
-	# clear all of the other variables
+        self.lca_scores = dict()        # keep track of lca scores
+        self.event_str = dict()         # keep track of events for each lca
+
+        # clear all of the other variables
         self.myBranch = None            # used to construct unrooted trees
-	self.branch_list = []           # used to construct unrooted trees
-	self.child_branches = []        # list of branches to kids
-	self.parent_branch = []         # should have length 1
-        
-	self.subnodes = dict()          # all nodes below this
-	self.leaves = None              # leaves below this
+        self.branch_list = []           # used to construct unrooted trees
+        self.child_branches = []        # list of branches to kids
+        self.parent_branch = []         # should have length 1
+
+        self.subnodes = dict()          # all nodes below this
+        self.leaves = None              # leaves below this
         self.leaf_nodes = []
-        
+
         # attach to each node a serial number, to tell nodes apart
-	#self.serial = random.randint(-sys.maxint,sys.maxint)
         self.serial = hash(self.name)
         self.newick_string = ""
         self.counts_dict = {}
         self.ancestors = []
 
-	self.visited = False            # useful for rooting trees
+        self.visited = False            # useful for rooting trees
         self.dup_count = 0              # number of duplications at this node
 
         # things for GetNodeLinkDict
@@ -57,7 +57,7 @@ class node:
 
         # things necessary for UnrootedLeaving
         self.leaf_dict = {}
-        self.name_dict = {}        
+        self.name_dict = {}
         self.branch_dict = {}
         self.unrooted_leaving_visited = False
         self.other_nodes = []
@@ -68,57 +68,44 @@ class node:
 
         # ML things
         self.ML_probs = {}
-        self.ML_null_probs = {}        
+        self.ML_null_probs = {}
         self.ML_state = {}
-        self.old_state = array([0,0,0])
+        self.old_state = array([0, 0, 0])
         self.sum_lik = 0
 
         # cluster things
         self.confidence = math.exp(100)
-        
+
     def __repr__(self):
-	#if self.myBranch == None:
-	#    return self.name
-	#else:	
-	#    return self.name + ":" + str(self.myBranch.length)
-        return self.name 
-    
-    def __eq__(self,other):
-	if self is None or other is None:
-	    return False
-	elif self.serial == other.serial:
-	    return True
-	else:
-	    return False
+        return self.name
 
-    def __ne__(self,other):
+    def __eq__(self, other):
+        if self is None or other is None:
+            return False
+        elif self.serial == other.serial:
+            return True
+        else:
+            return False
 
-	if self is None or other is None:
-	    return True
-	elif self.serial == other.serial:
-	    return False
-	else:
-	    return True
+    def __ne__(self, other):
+        if self is None or other is None:
+            return True
+        elif self.serial == other.serial:
+            return False
+        else:
+            return True
 
-    def __gt__(self,other):
-	if self.name > other.name:
-	    return True
-	else:
-	    return False
+    def __gt__(self, other):
+        return self.name > other.name
 
-    def __lt__(self,other):
-	if self.name < other.name:
-	    return True
-	else:
-	    return False
+    def __lt__(self, other):
+        return self.name < other.name
+
     def __hash__(self):
         return self.serial
 
     def isLeaf(self):
-	if len(self.child_branches) < 1:
-	    return True
-	else:
-	    return False
+        return len(self.child_branches) < 1
 
     def GetKids(self):
         kids = []
@@ -127,28 +114,25 @@ class node:
                 if j is not self:
                     kids.append(j)
         return kids
-	
+
     def PrintStates(this_node):
 
         if len(this_node.ML_state) > 0:
             if max(this_node.ML_state.values()) > 0:
 
-                print "node:",
-                node_name = this_node.treePrint("",0)
-                if node_name[0] is not "(":
-                    print "(" + node_name + ")"
+                print("node:", end=' ')
+                node_name = this_node.treePrint("", 0)
+                if node_name[0] != "(":
+                    print("(" + node_name + ")")
                 else:
-                    print node_name
-                print "prob:",
+                    print(node_name)
+                print("prob:", end=' ')
                 for state in this_node.ML_state:
-                    print state + ":", round(this_node.ML_state[state],3), 
-                print
+                    print(state + ":", round(this_node.ML_state[state], 3), end=' ')
+                print()
 
-                print "lik:", this_node.sum_lik
-                
-                #for state in this_node.ML_probs:
-                #    print state + ":", round(this_node.ML_probs[state],3), 
-                print
+                print("lik:", this_node.sum_lik)
+                print()
 
         for branch in this_node.child_branches:
             for kid_node in branch.ends:
@@ -163,8 +147,8 @@ class node:
                 if i is not this_node:
                     parent = i
         return parent
-	
-    def SaveStates(this_node,perturb_log):
+
+    def SaveStates(this_node, perturb_log):
 
         if len(this_node.ML_state) > 0:
             if max(this_node.ML_state.values()) > 0:
@@ -180,24 +164,22 @@ class node:
                 if kid_node is not this_node:
                     kid_node.SaveStates(perturb_log)
 
-
-
     # recursively print out nodes
-    def BootPrint(self,newickString,verbose=1):
+    def BootPrint(self, newickString, verbose=1):
 
-	count = 0
+        count = 0
 
-	for kid_branches in self.child_branches:
-	    for kid_nodes in kid_branches.ends:
-		if kid_nodes is not self:
-		    if count == 0:
-			newickString += "("
-			newickString = kid_nodes.BootPrint(newickString,verbose)
-		    else:
-			newickString += ","
-			newickString = kid_nodes.BootPrint(newickString,verbose)
-			newickString += ")"
-		    count += 1
+        for kid_branches in self.child_branches:
+            for kid_nodes in kid_branches.ends:
+                if kid_nodes is not self:
+                    if count == 0:
+                        newickString += "("
+                        newickString = kid_nodes.BootPrint(newickString, verbose)
+                    else:
+                        newickString += ","
+                        newickString = kid_nodes.BootPrint(newickString, verbose)
+                        newickString += ")"
+                    count += 1
 
         # add ability to print state probabilities
         boot_str = ""
@@ -205,206 +187,186 @@ class node:
             if len(self.ML_state) > 0:
                 for i in self.ML_state:
                     boot_str += "|" + i + "|"
-                    boot_str += "-" + str(round(self.ML_state[i],3))
+                    boot_str += "-" + str(round(self.ML_state[i], 3))
 
         newickString += boot_str
 
         addString = ""
         if verbose:
             if len(self.parent_branch) > 0 and len(self.child_branches) == 0:
-                addString = self.name + ":" + str(self.parent_branch[0].length) 
-            elif len(self.parent_branch) > 0: 
+                addString = self.name + ":" + str(self.parent_branch[0].length)
+            elif len(self.parent_branch) > 0:
                 addString = ":" + str(self.parent_branch[0].length)
         else:
             if len(self.parent_branch) > 0 and len(self.child_branches) == 0:
-                addString = self.species + ":" + str(self.parent_branch[0].length) 
-            elif len(self.parent_branch) > 0: 
+                addString = self.species + ":" + str(self.parent_branch[0].length)
+            elif len(self.parent_branch) > 0:
                 addString = ":" + str(self.parent_branch[0].length)
 
-	return newickString + addString
-                
+        return newickString + addString
 
-    def addBranch(self,length):
-
-	self.myBranch = branch.branch(length)
-	self.myBranch.addNode(self)
+    def addBranch(self, length):
+        self.myBranch = branch.branch(length)
+        self.myBranch.addNode(self)
 
     # recursively print out nodes
-    def treePrint(self,newickString,verbose=1):
+    def treePrint(self, newickString, verbose=1):
 
-	count = 0
+        count = 0
 
-	for kid_branches in self.child_branches:
-	    for kid_nodes in kid_branches.ends:
-		if kid_nodes is not self:
-		    if count == 0:
-			newickString += "("
-			newickString = kid_nodes.treePrint(newickString,verbose)
-		    else:
-			newickString += ","
-			newickString = kid_nodes.treePrint(newickString,verbose)
-			newickString += ")"
-		    count += 1
+        for kid_branches in self.child_branches:
+            for kid_nodes in kid_branches.ends:
+                if kid_nodes is not self:
+                    if count == 0:
+                        newickString += "("
+                        newickString = kid_nodes.treePrint(newickString, verbose)
+                    else:
+                        newickString += ","
+                        newickString = kid_nodes.treePrint(newickString, verbose)
+                        newickString += ")"
+                    count += 1
 
         addString = ""
 
         if verbose:
             if len(self.parent_branch) > 0 and len(self.child_branches) == 0:
-                addString = self.name + ":" + str(self.parent_branch[0].length) 
-            elif len(self.parent_branch) > 0: 
+                addString = self.name + ":" + str(self.parent_branch[0].length)
+            elif len(self.parent_branch) > 0:
                 addString = ":" + str(self.parent_branch[0].length)
         else:
             if len(self.parent_branch) > 0 and len(self.child_branches) == 0:
-                addString = self.name 
-	return newickString + addString
+                addString = self.name
+        return newickString + addString
 
     # join two nodes in a central node
-    def unite(self,node2):
+    def unite(self, node2):
 
-	# create a new node
-	new_node_name = self.name + "-" + node2.name
-	center_node = node(new_node_name,self.tree)
-	self.myBranch.addNode(center_node)
-	node2.myBranch.addNode(center_node)
-	return center_node
+        # create a new node
+        new_node_name = self.name + "-" + node2.name
+        center_node = node(new_node_name, self.tree)
+        self.myBranch.addNode(center_node)
+        node2.myBranch.addNode(center_node)
+        return center_node
 
     # recursively impose a hierarchy
     def imposeHierarchy(self):
 
-	# find all the child nodes that have yet to be visited and
-	# assign their children
-	for kid_branch in self.child_branches:
-	    for node in kid_branch.ends:
-		if not node.visited and node is not self:
-		    node.visited = True
-		    node.parent_branch.append(kid_branch)
-		    for child_branch in node.branch_list:
-			if child_branch is not kid_branch:
-			    node.child_branches.append(child_branch)
-			    node.imposeHierarchy()
+        # find all the child nodes that have yet to be visited and
+        # assign their children
+        for kid_branch in self.child_branches:
+            for node in kid_branch.ends:
+                if not node.visited and node is not self:
+                    node.visited = True
+                    node.parent_branch.append(kid_branch)
+                    for child_branch in node.branch_list:
+                        if child_branch is not kid_branch:
+                            node.child_branches.append(child_branch)
+                            node.imposeHierarchy()
 
-    # recursively label the roots of subtrees w/ the leaves contained
-    # below
+    # recursively label the roots of subtrees w/ the leaves contained below
     def subtreeLabel(self):
 
-	leaf_vec = []
-	
-	if self.leaves is not None:
-	    return self.leaves
+        leaf_vec = []
 
-	# recurse
+        if self.leaves is not None:
+            return self.leaves
+
+        # recurse
         kids = self.GetKids()
         for kid in kids:
             child_leaves = kid.subtreeLabel()
             leaf_vec.extend(child_leaves)
 
-	# once you hit a leaf
-	if len(self.child_branches) == 0:
-	    leaf_vec.append(self.species)
+        # once you hit a leaf
+        if len(self.child_branches) == 0:
+            leaf_vec.append(self.species)
             self.leaf_nodes.append(self)
         else:
             for kid in kids:
                 self.leaf_nodes.extend(kid.leaf_nodes)
-            
-	# non-duplicates:
-	leaf_vec = dict(map(lambda i: (i,1),leaf_vec))
-	self.leaves = leaf_vec
-	return leaf_vec.keys()
+
+        # non-duplicates
+        leaf_vec = dict(map(lambda i: (i, 1), leaf_vec))
+        self.leaves = leaf_vec
+        return list(leaf_vec.keys())
 
     # figure out which species tree node a gene tree node maps to
-    def subtreeMap(self,species_node):
-	
-	# do the children of the current species node possess the
-	# relevant genes?  if so, follow that child.  if not, return
-	# the current node
+    def subtreeMap(self, species_node):
 
-	foundSet = 0
-	for kid_branches in species_node.child_branches:
-	    for kid_nodes in kid_branches.ends:
-		if kid_nodes is not species_node:
+        foundSet = 0
+        for kid_branches in species_node.child_branches:
+            for kid_nodes in kid_branches.ends:
+                if kid_nodes is not species_node:
 
-		    s_leaves = kid_nodes.leaves
-		    g_leaves = self.leaves
+                    s_leaves = kid_nodes.leaves
+                    g_leaves = self.leaves
 
-		    # count how many elements of the gene set of
-		    # leaves are not in the species set of leaves
+                    n = 0
+                    for i in g_leaves.keys():
+                        if not i in s_leaves:
+                            n += 1
+                            break
 
-		    n = 0
-		    for i in g_leaves.keys():
-			if not i in s_leaves:
-			    n += 1
-			    break
-		    
-		    # if you can see somewhere to descend, follow it
-		    if n == 0:
-			return self.subtreeMap(kid_nodes)
+                    if n == 0:
+                        return self.subtreeMap(kid_nodes)
 
-	# once you've run out of places to descend, just return
-	# wherever you've ended up:
-	return species_node
+        return species_node
 
     # recursively store at each node a hash of all nodes below
     def Find_Subnodes(self):
 
-	for kid_branches in self.child_branches:
-	    for kid_nodes in kid_branches.ends:
-		if kid_nodes is not self:
-		    new_dict = kid_nodes.Find_Subnodes()
-		    for k in new_dict.keys():
-			if not k in self.subnodes:
-			    self.subnodes[k] = 1
-		    # self.subnodes.extend(kid_nodes.Find_Subnodes())
+        for kid_branches in self.child_branches:
+            for kid_nodes in kid_branches.ends:
+                if kid_nodes is not self:
+                    new_dict = kid_nodes.Find_Subnodes()
+                    for k in new_dict.keys():
+                        if not k in self.subnodes:
+                            self.subnodes[k] = 1
 
-	# self.subnodes.append(self)
-	self.subnodes[self.species] = 1
-	return self.subnodes
+        self.subnodes[self.species] = 1
+        return self.subnodes
 
-    # find the last common ancestor of two nodes.  will descend from
-    # the subroot (self) looking to see which children possess both
-    # nodes.  if neither children possess both nodes, return current
-    # node
-
-    def Find_LCA(self,node1,node2):
+    # find the last common ancestor of two nodes.
+    def Find_LCA(self, node1, node2):
 
         for kid_branches in self.child_branches:
             for kid_nodes in kid_branches.ends:
                 if kid_nodes is not self:
                     if node1.species in kid_nodes.subnodes:
                         if node2.species in kid_nodes.subnodes:
-                            return kid_nodes.Find_LCA(node1,node2)
+                            return kid_nodes.Find_LCA(node1, node2)
         return self
 
     # get list of all vertices in a tree
     def Fill_Node_Dict(vertex):
-	
-	# vertex.tree.node_dict[vertex.name] = vertex
+
         vertex.tree.node_dict[vertex.name] = vertex
 
-	for kid_branches in vertex.child_branches:
-	    for kid_nodes in kid_branches.ends:
-		if kid_nodes is not vertex:
-		    kid_nodes.Fill_Node_Dict()
+        for kid_branches in vertex.child_branches:
+            for kid_nodes in kid_branches.ends:
+                if kid_nodes is not vertex:
+                    kid_nodes.Fill_Node_Dict()
 
     # initialize hash tables for lca scores for each node
-    def Init_LCA_Scores(vertex,node_dict):
+    def Init_LCA_Scores(vertex, node_dict):
 
-	for tnode in node_dict:
-	    vertex.lca_scores[tnode.name] = node.maxInt
+        for tnode in node_dict:
+            vertex.lca_scores[tnode.name] = node.maxInt
 
-	for kid_branches in vertex.child_branches:
-	    for kid_nodes in kid_branches.ends:
-		if kid_nodes is not vertex:
-		    kid_nodes.Init_LCA_Scores(node_dict)
+        for kid_branches in vertex.child_branches:
+            for kid_nodes in kid_branches.ends:
+                if kid_nodes is not vertex:
+                    kid_nodes.Init_LCA_Scores(node_dict)
 
     # determine if one node is descended from the other ...
-    def Are_Related(node1,node2):
+    def Are_Related(node1, node2):
 
-	verdict = False
-	for e in node1.leaves.keys():
-	    if e in node2.leaves:
-		verdict = True
+        verdict = False
+        for e in node1.leaves.keys():
+            if e in node2.leaves:
+                verdict = True
 
-	return verdict
+        return verdict
 
     # method to list all the leaves of this node, keyed by the parent
     def UnrootedLeaving(this_node):
@@ -419,16 +381,16 @@ class node:
         # get leaves in each direction
         for parent_node in other_nodes:
 
-            child_nodes = list(Set(other_nodes).difference(Set([parent_node])))
-            this_node.GetChildLeaves(parent_node,child_nodes)
+            child_nodes = list(set(other_nodes).difference({parent_node}))
+            this_node.GetChildLeaves(parent_node, child_nodes)
 
         # when done, move on to neighboring nodes:
         for node in other_nodes:
 
-            if len(node.leaf_dict) is not len(node.branch_list):
+            if len(node.leaf_dict) != len(node.branch_list):
                 node.UnrootedLeaving()
-                
-    def GetLeaves(this_node,parent_node):
+
+    def GetLeaves(this_node, parent_node):
 
         # if the leaf dict has already been defined:
         if parent_node in this_node.leaf_dict:
@@ -436,7 +398,7 @@ class node:
 
         # if is a leaf
         if len(this_node.branch_list) < 2:
-            
+
             this_node.tree.leaf_node_list.append(this_node)
 
             if this_node.species in this_node.tree.species_count:
@@ -445,16 +407,16 @@ class node:
                 this_node.tree.species_count[this_node.species] = 1
 
             this_node.leaf_dict[parent_node] = [this_node.species]
-            this_node.name_dict[parent_node] = [this_node.name]          
+            this_node.name_dict[parent_node] = [this_node.name]
             return this_node.leaf_dict[parent_node], this_node.name_dict[parent_node]
 
         other_nodes = this_node.GetOtherNodes()
-        child_nodes = list(Set(other_nodes).difference(Set([parent_node])))
-        this_node.GetChildLeaves(parent_node,child_nodes)
-            
+        child_nodes = list(set(other_nodes).difference({parent_node}))
+        this_node.GetChildLeaves(parent_node, child_nodes)
+
         return this_node.leaf_dict[parent_node], this_node.name_dict[parent_node]
 
-    def GetChildLeaves(this_node,parent_node,other_nodes):
+    def GetChildLeaves(this_node, parent_node, other_nodes):
 
         merge_list = []
         name_list = []
@@ -465,7 +427,7 @@ class node:
                     continue
 
             kid_leaves, kid_names = kid_node.GetLeaves(this_node)
-            
+
             if type(kid_leaves[0]) is not type(''):
                 merge_list.extend(kid_leaves[0])
                 name_list.extend(kid_names[0])
@@ -473,7 +435,6 @@ class node:
                 merge_list.extend(kid_leaves)
                 name_list.extend(kid_names)
 
-            # this is a total hack
             this_node.leaf_dict[parent_node] = []
             this_node.name_dict[parent_node] = []
 
@@ -482,7 +443,7 @@ class node:
         this_node.leaf_dict[parent_node].extend(merge_list)
         this_node.name_dict[parent_node].extend(name_list)
 
-    def GetNodeLinkDict(this_node,node_link_dict):
+    def GetNodeLinkDict(this_node, node_link_dict):
 
         this_node.link_dict_visited = True
         leaf_dict = this_node.leaf_dict
@@ -493,17 +454,16 @@ class node:
             if type(subleaves[0]) == type([]):
                 subleaves = subleaves[0]
             sub_str = repr(subleaves)
-            
+
             if sub_str in node_link_dict:
-                node_link_dict[sub_str].append((this_node,key))
+                node_link_dict[sub_str].append((this_node, key))
             else:
-                node_link_dict[sub_str] = [(this_node,key)]
-            # node_link_dict[sub_str] = (this_node,key)
+                node_link_dict[sub_str] = [(this_node, key)]
 
         # after that's been done, decide where to recurse
         for relative in leaf_dict:
 
-            relative_keys = relative.leaf_dict.keys()
+            relative_keys = list(relative.leaf_dict.keys())
             subleaves = relative.leaf_dict[relative_keys[0]]
             subleaves.sort()
 
@@ -524,10 +484,8 @@ class node:
 
         return other_nodes
 
-    # get the distance between two nodes:
-    # call as follows:
-    # found, dist = node1.DistTo(node2)
-    def DistTo(this_node,that_node,this_branch=None,dist=0):
+    # get the distance between two nodes
+    def DistTo(this_node, that_node, this_branch=None, dist=0):
 
         # what to do at the end
         if this_node is that_node:
@@ -540,20 +498,20 @@ class node:
             if i is not this_branch:
                 for j in i.ends:
                     if j is not this_node:
-                        found, new_dist = j.DistTo(that_node,i,dist+i.immutable_length)
+                        found, new_dist = j.DistTo(that_node, i, dist + i.immutable_length)
                         if found is True:
                             was_found = found
                             found_dist = new_dist
 
         return was_found, found_dist
-        
+
     def NodeWipe(this_node):
 
         for kid_branches in this_node.child_branches:
             for kid_nodes in kid_branches.ends:
                 if kid_nodes is not this_node:
                     kid_nodes.NodeWipe()
-                        
+
         this_node.child_branches = []
         this_node.parent_branch = []
         this_node.subnodes = {}
@@ -561,7 +519,7 @@ class node:
         this_node.ML_state = {}
         this_node.ML_probs = {}
 
-    def LearnMR(this_node,MR_matrix,species_key):
+    def LearnMR(this_node, MR_matrix, species_key):
 
         if len(this_node.branches) < 1:
             pdb.set_trace()
@@ -569,5 +527,4 @@ class node:
         for i in this_node.child_branches:
             for j in i.ends:
                 if j is not this_node:
-                    j.LearnMR(MR_matrix,species_key)
-        
+                    j.LearnMR(MR_matrix, species_key)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-numpy==1.7.1
-scipy==0.10.1
+numpy>=1.24
+scipy>=1.10

--- a/wrapper/WrAdaptML.py
+++ b/wrapper/WrAdaptML.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
 # adaptML wrapper
 
@@ -8,18 +8,18 @@ import sys
 import shutil
 import subprocess as sub
 
-print "\nwelcome to WrAdaptML, the AdaptML wrapper."
+print("\nwelcome to WrAdaptML, the AdaptML wrapper.")
 
 if len(sys.argv) <= 1:
-    print 'Arguments are:'
-    print 'tree'
-    print 'init_hab_num'
-    print 'outgroup'
-    print 'converge_thresh'
-    print 'write_dir'
-    print 'rateopt'
-    print 'collapse_thresh'
-    print 'rand'
+    print('Arguments are:')
+    print('tree')
+    print('init_hab_num')
+    print('outgroup')
+    print('converge_thresh')
+    print('write_dir')
+    print('rateopt')
+    print('collapse_thresh')
+    print('rand')
 
 # read in the variables
 inputs = sys.argv
@@ -31,11 +31,11 @@ outgroup = None
 write_d = './'
 rateopt = 'avg'
 mu = 1.00000000001
-collapse_thresh = 0.10
-converge_thresh = 0.001
+collapse_thresh = "0.10"
+converge_thresh = "0.001"
 color_fn = None
 
-for ind in range(1,len(inputs)):
+for ind in range(1, len(inputs)):
     arg_parts = inputs[ind].split('=')
     code = arg_parts[0]
     arg = arg_parts[1]
@@ -56,17 +56,21 @@ for ind in range(1,len(inputs)):
     elif code == 'rand':
         rand_bool = True
         rand_iter_num = arg
-        
+
 ###############
 # run AdaptML #
 ###############
 
-print "Running AdaptML ..."
-wr_path_s = os.path.abspath(sys.argv[0])
-home_path = '/'.join(wr_path_s.split('/')[:5])
-adaptml_x = home_path + "/habitats/trunk/AdaptML.py"
+# Resolve the AdaptML source paths relative to this wrapper, regardless of cwd
+base_path = os.path.dirname(os.path.realpath(__file__)) + '/../'
+
+# Make sure the write directory exists
+os.makedirs(write_d, exist_ok=True)
+
+print("Running AdaptML ...")
+adaptml_x = base_path + "habitats/trunk/AdaptML.py"
 adaptml_l = []
-adaptml_l.append("/usr/local/bin/python2.5")
+adaptml_l.append(sys.executable)
 adaptml_l.append(adaptml_x)
 adaptml_l.append("tree=" + tree_fn)
 adaptml_l.append("init_hab_num=" + init_hab_num)
@@ -75,30 +79,30 @@ adaptml_l.append("write_dir=" + write_d)
 adaptml_l.append("collapse_thresh=" + collapse_thresh)
 adaptml_l.append("converge_thresh=" + converge_thresh)
 adaptml_l.append("rateopt=" + rateopt)
-proc = sub.Popen(adaptml_l,stdout=sub.PIPE, stderr=sub.PIPE)
+proc = sub.Popen(adaptml_l, stdout=sub.PIPE, stderr=sub.PIPE)
 
 # wait until finished
-stdout,stderr = proc.communicate()
+stdout, stderr = proc.communicate()
 
-if stderr != '':
-    print stdout
-    print 'Errors:'
-    print stderr
+if stderr:
+    print(stdout.decode('utf-8', errors='replace'))
+    print('Errors:')
+    print(stderr.decode('utf-8', errors='replace'))
     sys.exit()
 
 ##############
 # run RandML #
 ##############
 
-print "Running RandML ..."
+print("Running RandML ...")
 emp_d = write_d + "/emp_trees/"
 if os.path.exists(emp_d):
     shutil.rmtree(emp_d)
 os.mkdir(emp_d)
 
-randml_x = home_path + "/clusters/getstats/rand_JointML.py"
+randml_x = base_path + "clusters/getstats/rand_JointML.py"
 randml_l = []
-randml_l.append("/usr/local/bin/python2.5")
+randml_l.append(sys.executable)
 randml_l.append(randml_x)
 randml_l.append("tree=" + tree_fn)
 randml_l.append("outgroup=" + outgroup)
@@ -106,7 +110,6 @@ randml_l.append("write=" + emp_d)
 randml_l.append("habitats=" + write_d + "/habitat.matrix")
 randml_l.append("mu=" + write_d + "/mu.val")
 randml_l.append("iters=" + rand_iter_num)
-proc = sub.Popen(randml_l,stdout=sub.PIPE)
+proc = sub.Popen(randml_l, stdout=sub.PIPE)
 # wait until finished
-stdout,stderr = proc.communicate()
-
+stdout, stderr = proc.communicate()

--- a/wrapper/WrAdaptMLFile.py
+++ b/wrapper/WrAdaptMLFile.py
@@ -1,6 +1,6 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
-# adaptML wrapper
+# adaptML wrapper that reads its settings from a single config file
 
 import os
 import pdb
@@ -9,25 +9,25 @@ import shutil
 import subprocess as sub
 
 if len(sys.argv) != 2:
-    print "Please supply a single input file to read AdaptML settings from"
+    print("Please supply a single input file to read AdaptML settings from")
+    sys.exit(1)
 
 # Read input file
 file_location = sys.argv[1]
-file_handle = open(file_location, 'r')
-run_configs = file_handle.read()
-file_handle.close()
+with open(file_location, 'r') as f:
+    run_configs = f.read()
 
 # Parse input file into dictionary
 file_data = run_configs.split("\n")
 run_config = {}
 for line in file_data:
-    line = line.split('=')
-    if len(line) == 1:
+    line_parts = line.split('=')
+    if len(line_parts) == 1:
         continue
-    if len(line) != 2:
-        raise ValueError("Cannot parse line "+str(line))
-    key = line[0].strip()
-    value = line[1].strip()
+    if len(line_parts) != 2:
+        raise ValueError("Cannot parse line " + str(line_parts))
+    key = line_parts[0].strip()
+    value = line_parts[1].strip()
     run_config[key] = value
 
 # Create variable defaults
@@ -39,8 +39,8 @@ outgroup = None
 write_d = './'
 rateopt = 'avg'
 mu = 1.00000000001
-collapse_thresh = 0.10
-converge_thresh = 0.001
+collapse_thresh = "0.10"
+converge_thresh = "0.001"
 color_fn = None
 
 # Set Variables
@@ -62,16 +62,19 @@ for code, arg in run_config.items():
     elif code == 'rand':
         rand_bool = True
         rand_iter_num = arg
-        
+
 ###############
 # run AdaptML #
 ###############
 
-print "Running AdaptML ..."
-base_path = os.path.dirname(os.path.realpath(__file__))+'/../'
-adaptml_x = base_path + "/habitats/trunk/AdaptML.py"
+# Make sure the write directory exists
+os.makedirs(write_d, exist_ok=True)
+
+print("Running AdaptML ...")
+base_path = os.path.dirname(os.path.realpath(__file__)) + '/../'
+adaptml_x = base_path + "habitats/trunk/AdaptML.py"
 adaptml_l = []
-adaptml_l.append("python")
+adaptml_l.append(sys.executable)
 adaptml_l.append(adaptml_x)
 adaptml_l.append("tree=" + tree_fn)
 adaptml_l.append("init_hab_num=" + init_hab_num)
@@ -80,30 +83,30 @@ adaptml_l.append("write_dir=" + write_d)
 adaptml_l.append("collapse_thresh=" + collapse_thresh)
 adaptml_l.append("converge_thresh=" + converge_thresh)
 adaptml_l.append("rateopt=" + rateopt)
-proc = sub.Popen(adaptml_l,stdout=sub.PIPE, stderr=sub.PIPE)
+proc = sub.Popen(adaptml_l, stdout=sub.PIPE, stderr=sub.PIPE)
 
 # wait until finished
-stdout,stderr = proc.communicate()
+stdout, stderr = proc.communicate()
 
-if stderr != '':
-    print stdout
-    print 'Errors:'
-    print stderr
+if stderr:
+    print(stdout.decode('utf-8', errors='replace'))
+    print('Errors:')
+    print(stderr.decode('utf-8', errors='replace'))
     sys.exit()
 
 ##############
 # run RandML #
 ##############
 
-print "Running RandML ..."
+print("Running RandML ...")
 emp_d = write_d + "/emp_trees/"
 if os.path.exists(emp_d):
     shutil.rmtree(emp_d)
 os.mkdir(emp_d)
 
-randml_x = base_path + "/clusters/getstats/rand_JointML.py"
+randml_x = base_path + "clusters/getstats/rand_JointML.py"
 randml_l = []
-randml_l.append("python")
+randml_l.append(sys.executable)
 randml_l.append(randml_x)
 randml_l.append("tree=" + tree_fn)
 randml_l.append("outgroup=" + outgroup)
@@ -111,7 +114,6 @@ randml_l.append("write=" + emp_d)
 randml_l.append("habitats=" + write_d + "/habitat.matrix")
 randml_l.append("mu=" + write_d + "/mu.val")
 randml_l.append("iters=" + rand_iter_num)
-proc = sub.Popen(randml_l,stdout=sub.PIPE)
+proc = sub.Popen(randml_l, stdout=sub.PIPE)
 # wait until finished
-stdout,stderr = proc.communicate()
-
+stdout, stderr = proc.communicate()

--- a/wrapper/WrapLikelihood.py
+++ b/wrapper/WrapLikelihood.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
 # adaptML wrapper
 
@@ -8,7 +8,7 @@ import sys
 import shutil
 import subprocess as sub
 
-print "\nwelcome to WrapLikelihood, the AdaptML wrapper."
+print("\nwelcome to WrapLikelihood, the AdaptML wrapper.")
 
 # read in the variables
 inputs = sys.argv
@@ -16,12 +16,11 @@ tree_fn = None
 outgroup = None
 write_d = './'
 color_fn = None
-thresh_p = 0.95
+thresh_p = "0.95"
 
-wr_path_s = os.path.abspath(sys.argv[0])
-home_path = '/'.join(wr_path_s.split('/')[:5])
+base_path = os.path.dirname(os.path.realpath(__file__)) + '/../'
 
-for ind in range(1,len(inputs)):
+for ind in range(1, len(inputs)):
     arg_parts = inputs[ind].split('=')
     code = arg_parts[0]
     arg = arg_parts[1]
@@ -35,32 +34,32 @@ for ind in range(1,len(inputs)):
         color_fn = arg
     elif code == 'thresh':
         thresh_p = arg
-        
+
 ###################
 # get likelihoods #
 ###################
 
-print "Obtaining empirical thresholds ..."
+print("Obtaining empirical thresholds ...")
 
-getliks_x = home_path + "/clusters/getstats/GetLikelihoods.py"
+getliks_x = base_path + "clusters/getstats/GetLikelihoods.py"
 getliks_l = []
-getliks_l.append("/usr/local/bin/python2.5")
+getliks_l.append(sys.executable)
 getliks_l.append(getliks_x)
 getliks_l.append(write_d + "/emp_trees/")
 getliks_l.append(write_d)
-getliks_l.append(thresh_p)
-proc = sub.Popen(getliks_l,stdout=sub.PIPE)
+getliks_l.append(str(thresh_p))
+proc = sub.Popen(getliks_l, stdout=sub.PIPE)
 # wait until finished
-stdout,stderr = proc.communicate()
+stdout, stderr = proc.communicate()
 
 ###############
-# run JointML # 
+# run JointML #
 ###############
 
-print "Running JointML ..."
-jointml_x = home_path + "/clusters/trunk/JointML.py"
+print("Running JointML ...")
+jointml_x = base_path + "clusters/trunk/JointML.py"
 jointml_l = []
-jointml_l.append("/usr/local/bin/python2.5")
+jointml_l.append(sys.executable)
 jointml_l.append(jointml_x)
 jointml_l.append("tree=" + tree_fn)
 jointml_l.append("outgroup=" + outgroup)
@@ -70,7 +69,7 @@ jointml_l.append("mu=" + write_d + "/mu.val")
 jointml_l.append("color=" + color_fn)
 jointml_l.append("thresh=" + write_d + "/thresh.file")
 
-proc = sub.Popen(jointml_l,stdout=sub.PIPE)
+proc = sub.Popen(jointml_l, stdout=sub.PIPE)
 
 # wait until finished
-stdout,stderr = proc.communicate()
+stdout, stderr = proc.communicate()

--- a/wrapper/WrapLikelihoodFile.py
+++ b/wrapper/WrapLikelihoodFile.py
@@ -1,6 +1,6 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
-# adaptML wrapper
+# adaptML wrapper that reads its settings from a single config file
 
 import os
 import pdb
@@ -9,25 +9,25 @@ import shutil
 import subprocess as sub
 
 if len(sys.argv) != 2:
-    print "Please supply a single input file to read settings from"
-    
+    print("Please supply a single input file to read settings from")
+    sys.exit(1)
+
 # Read input file
 file_location = sys.argv[1]
-file_handle = open(file_location, 'r')
-run_configs = file_handle.read()
-file_handle.close()
+with open(file_location, 'r') as f:
+    run_configs = f.read()
 
 # Parse input file into dictionary
 file_data = run_configs.split("\n")
 run_config = {}
 for line in file_data:
-    line = line.split('=')
-    if len(line) == 1:
+    line_parts = line.split('=')
+    if len(line_parts) == 1:
         continue
-    if len(line) != 2:
-        raise ValueError("Cannot parse line "+str(line))
-    key = line[0].strip()
-    value = line[1].strip()
+    if len(line_parts) != 2:
+        raise ValueError("Cannot parse line " + str(line_parts))
+    key = line_parts[0].strip()
+    value = line_parts[1].strip()
     run_config[key] = value
 
 
@@ -50,32 +50,32 @@ for code, arg in run_config.items():
         color_fn = arg
     elif code == 'thresh':
         thresh_p = arg
-        
+
 ###################
 # get likelihoods #
 ###################
 
-print "Obtaining empirical thresholds ..."
-base_path = os.path.dirname(os.path.realpath(__file__))+'/../'
+print("Obtaining empirical thresholds ...")
+base_path = os.path.dirname(os.path.realpath(__file__)) + '/../'
 getliks_x = base_path + "clusters/getstats/GetLikelihoods.py"
 getliks_l = []
-getliks_l.append("python")
+getliks_l.append(sys.executable)
 getliks_l.append(getliks_x)
 getliks_l.append(write_d + "/emp_trees/")
 getliks_l.append(write_d)
-getliks_l.append(thresh_p)
-proc = sub.Popen(getliks_l,stdout=sub.PIPE)
+getliks_l.append(str(thresh_p))
+proc = sub.Popen(getliks_l, stdout=sub.PIPE)
 # wait until finished
-stdout,stderr = proc.communicate()
+stdout, stderr = proc.communicate()
 
 ###############
-# run JointML # 
+# run JointML #
 ###############
 
-print "Running JointML ..."
+print("Running JointML ...")
 jointml_x = base_path + "clusters/trunk/JointML.py"
 jointml_l = []
-jointml_l.append("python")
+jointml_l.append(sys.executable)
 jointml_l.append(jointml_x)
 jointml_l.append("tree=" + tree_fn)
 jointml_l.append("outgroup=" + outgroup)
@@ -85,7 +85,7 @@ jointml_l.append("mu=" + write_d + "/mu.val")
 jointml_l.append("color=" + color_fn)
 jointml_l.append("thresh=" + write_d + "/thresh.file")
 
-proc = sub.Popen(jointml_l,stdout=sub.PIPE)
+proc = sub.Popen(jointml_l, stdout=sub.PIPE)
 
 # wait until finished
-stdout,stderr = proc.communicate()
+stdout, stderr = proc.communicate()


### PR DESCRIPTION
## Summary

- **Python 3 port**: All 20 legacy Python 2.5 files in `habitats/`, `clusters/`, and `wrapper/` updated to run on Python 3 + NumPy ≥ 1.24 / SciPy ≥ 1.10. Key fixes: `dict.keys()[i]` views, `filter()` iterators, `sys.maxint`, `time.clock()`, `from sets import Set`, `from numpy.matlib import *`, mixed tab/space indentation, numpy 2.x `sum` shadowing, and hardcoded Python 2 interpreter paths in wrappers.
- **`adaptml.html`**: New single self-contained browser app — complete JS reimplementation of the AdaptML algorithm (EM habitat learning → joint Viterbi cluster identification → leaf-shuffle empirical null) running in a Web Worker. Outputs a ZIP of modern iTOL-format files (`TREE_COLORS`, `DATASET_SYMBOL`, `DATASET_COLORSTRIP`, `DATASET_MULTIBAR`) plus JSON/TSV. SCELSE-branded UI.
- **Bug fix**: Cluster deduplication — `findDivergence` was treating `trueRoot` as a divergence point (its parent, the synthetic outgroup root, has no habitat), causing every cluster to be written twice to `dataset_population_strips.txt`. Fixed by skipping `trueRoot` in `findDivergence` and guarding `clusters.push` with a `cluster_root` flag.
- **Config**: `example/adaptml.file` `init_hab_num` corrected to 16; `example/likelihood.file` `thresh` corrected to 0.9999 (both match published paper defaults).
- **Docs**: Full README rewrite with Python 3 quickstart, browser app usage, iTOL output guide, and stop-server command. New `CLAUDE.md` architecture guide.

## Reviewer notes

- The browser app requires a local HTTP server (`python3 -m http.server 8000`) only for the "Load example" fetch; it otherwise runs fully offline.
- Publication-grade run takes ~10 min in the browser (10 000 randomization iterations at p = 0.9999). The UI exposes a seed field (default 2727) for reproducibility.
- iTOL tip: after uploading `dataset_population_strips.txt`, set **Colored ranges → Cover → Clade** to render populations as filled wedge sectors matching Fig. 1A.

## Test plan

- [ ] `python3 wrapper/WrAdaptMLFile.py example/adaptml.file` completes without errors, produces `habitat.matrix` and `mu.val`
- [ ] `python3 wrapper/WrapLikelihoodFile.py example/likelihood.file` completes, produces `itol.tree`, `cluster.file`, `strain.names`
- [ ] `python3 -m http.server 8000` → open `adaptml.html` → Load example → Run AdaptML → download ZIP → upload to iTOL

🤖 Generated with [Claude Code](https://claude.ai/claude-code)